### PR TITLE
TDI-32783: "ca.ingres.jdbc.IngresDriver" have been removed in Ingres new

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/database/EDatabase4DriverClassName.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/database/EDatabase4DriverClassName.java
@@ -33,7 +33,7 @@ public enum EDatabase4DriverClassName {
     IBMDB2ZOS(EDatabaseTypeName.IBMDB2ZOS, "COM.ibm.db2os390.sqlj.jdbc.DB2SQLJDriver"), //$NON-NLS-1$
 
     INFORMIX(EDatabaseTypeName.INFORMIX, "com.informix.jdbc.IfxDriver"), //$NON-NLS-1$
-    INGRES(EDatabaseTypeName.INGRES, "ca.ingres.jdbc.IngresDriver"), //$NON-NLS-1$
+    INGRES(EDatabaseTypeName.INGRES, "com.ingres.jdbc.IngresDriver"), //$NON-NLS-1$
     INTERBASE(EDatabaseTypeName.INTERBASE, "interbase.interclient.Driver"), //$NON-NLS-1$
     VECTORWISE(EDatabaseTypeName.VECTORWISE, "com.ingres.jdbc.IngresDriver"), //$NON-NLS-1$
 

--- a/main/plugins/org.talend.metadata.managment/src/main/java/org/talend/core/model/metadata/builder/database/dburl/SupportDBUrlType.java
+++ b/main/plugins/org.talend.metadata.managment/src/main/java/org/talend/core/model/metadata/builder/database/dburl/SupportDBUrlType.java
@@ -141,7 +141,7 @@ public enum SupportDBUrlType {
                        "org.firebirdsql.jdbc.FBDriver", //$NON-NLS-1$
                        null,
                        "FireBird"), //$NON-NLS-1$
-    INGRESDEFAULTURL("Ingres", "localhost", "II7", "dbname", null, "ca.ingres.jdbc.IngresDriver", null, "Ingres"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+    INGRESDEFAULTURL("Ingres", "localhost", "II7", "dbname", null, "com.ingres.jdbc.IngresDriver", null, "Ingres"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
     SQLITE3DEFAULTURL("SQLite", "localhost", "", "dbname", null, "org.sqlite.JDBC", null, "SQLite"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
     GENERICJDBCDEFAULTURL("General JDBC", "", "", "", null, "", null, "General JDBC"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
     // MOD klliu 2010-06-04 bug 12819: upgrade jdbc driver class used in sql explorer


### PR DESCRIPTION
JDBC driver
https://jira.talendforge.org/browse/TDI-32783