### PR TITLE
TDI-34018: A wrong migration task  in TDI-31497 for use batch cause old

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/components/ComponentUtilities.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/components/ComponentUtilities.java
@@ -23,6 +23,7 @@ import org.talend.commons.CommonsPlugin;
 import org.talend.commons.model.components.IComponentConstants;
 import org.talend.core.model.process.UniqueNodeNameGenerator;
 import org.talend.designer.core.model.utils.emf.talendfile.ColumnType;
+import org.talend.designer.core.model.utils.emf.talendfile.ConnectionType;
 import org.talend.designer.core.model.utils.emf.talendfile.ContextType;
 import org.talend.designer.core.model.utils.emf.talendfile.ElementParameterType;
 import org.talend.designer.core.model.utils.emf.talendfile.ElementValueType;
@@ -219,5 +220,18 @@ public final class ComponentUtilities {
             }
         }
         return isVisible;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static List<ConnectionType> getNodeOutputConnections(NodeType node) {
+        ProcessType processType = getNodeProcessType(node);
+        String nodeUniqueName = getNodeUniqueName(node);
+        List<ConnectionType> connList = new ArrayList<ConnectionType>();
+        for (ConnectionType conn : (List<ConnectionType>) processType.getConnection()) {
+            if (conn.getSource().equals(nodeUniqueName)) {
+                connList.add(conn);
+            }
+        }
+        return connList;
     }
 }


### PR DESCRIPTION
jobs which include tOracleOutput/tTeradataOutput with reject row have an
error alarm
https://jira.talendforge.org/browse/TDI-34018