### PR TITLE
Update master version to 6.1.0 (necessary for migration tasks).

### DIFF
--- a/main/plugins/org.talend.commons.runtime/talend.properties
+++ b/main/plugins/org.talend.commons.runtime/talend.properties
@@ -1,1 +1,1 @@
-talend.version=6.0.1
+talend.version=6.1.0


### PR DESCRIPTION
Can we update this file to 6.1.0 right away on master?  Leaving it at 6.0.1 causes the studio to fail after 6.1.0 migration tasks are applied to a workspace project.