### PR TITLE
TDI-34435: Change build.properties of org.talend.libraries.apache.cxf to

### DIFF
--- a/main/plugins/org.talend.libraries.apache.cxf/build.properties
+++ b/main/plugins/org.talend.libraries.apache.cxf/build.properties
@@ -43,4 +43,25 @@ bin.includes = META-INF/,\
                lib/cxf-rt-databinding-jaxb-3.1.3.jar,\
                lib/cxf-rt-frontend-jaxrs-3.1.3.jar,\
                lib/cxf-rt-rs-client-3.1.3.jar,\
-               lib/cxf-rt-transports-http-3.1.3.jar
+               lib/cxf-rt-transports-http-3.1.3.jar,\
+               lib/cxf-rt-bindings-soap-3.1.3.jar,\
+               lib/cxf-rt-bindings-xml-3.1.3.jar,\
+               lib/cxf-rt-databinding-xmlbeans-3.1.3.jar,\
+               lib/cxf-rt-frontend-simple-3.1.3.jar,\
+               lib/cxf-rt-frontend-jaxws-3.1.3.jar,\
+               lib/cxf-rt-security-3.1.3.jar,\
+               lib/cxf-rt-ws-addr-3.1.3.jar,\
+               lib/cxf-rt-ws-mex-3.1.3.jar,\
+               lib/cxf-rt-ws-policy-3.1.3.jar,\
+               lib/cxf-rt-ws-rm-3.1.3.jar,\
+               lib/wss4j-ws-security-stax-2.1.3.jar,\
+               lib/wss4j-ws-security-policy-stax-2.1.3.jar,\
+               lib/wss4j-ws-security-dom-2.1.3.jar,\
+               lib/wss4j-ws-security-common-2.1.3.jar,\
+               lib/wss4j-policy-2.1.3.jar,\
+               lib/wss4j-bindings-2.1.3.jar,\
+               lib/cxf-tools-common-3.1.3.jar,\
+               lib/cxf-services-sts-core-3.1.3.jar,\
+               lib/cxf-rt-transports-http-jetty-3.1.3.jar,\
+               lib/cxf-rt-ws-security-3.1.3.jar,\
+               lib/cxf-rt-wsdl-3.1.3.jar


### PR DESCRIPTION
include cxf-tools-common-3.1.3.jar
https://jira.talendforge.org/browse/TDI-34435