### PR TITLE
TDKN-26 Update studio to use Daikon 0.12.0-SNAPSHOT refactoring

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/metadata/MetadataToolAvroHelper.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/metadata/MetadataToolAvroHelper.java
@@ -30,10 +30,8 @@ import org.talend.core.model.metadata.builder.connection.MetadataTable;
 import org.talend.core.model.metadata.types.JavaTypesManager;
 import org.talend.core.utils.TalendQuoteUtils;
 import org.talend.cwm.helper.TaggedValueHelper;
-import org.talend.daikon.avro.util.AvroTypes;
-import org.talend.daikon.avro.util.AvroUtils;
-import org.talend.daikon.talend6.Talend6SchemaConstants;
-
+import org.talend.daikon.avro.AvroUtils;
+import org.talend.daikon.di.DiSchemaConstants;
 import orgomg.cwm.objectmodel.core.Expression;
 import orgomg.cwm.objectmodel.core.TaggedValue;
 
@@ -69,7 +67,7 @@ public final class MetadataToolAvroHelper {
             // store all the dynamic column's properties
             schema = copyDynamicColumnProperties(schema, dynColumn);
             // store dynamic position
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION,
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION,
                     String.valueOf(dynamicPosition));
             // tag avro schema with include-all-columns
             schema = AvroUtils.setIncludeAllFields(schema, true);
@@ -90,17 +88,17 @@ public final class MetadataToolAvroHelper {
 
         // FIXME: I comment it. I think there is no need to care id.
         // if (in.getId() != null) {
-        // builder.prop(Talend6SchemaConstants.TALEND6_ID, in.getId());
+        // builder.prop(DiSchemaConstants.TALEND6_ID, in.getId());
         // }
         if (in.getComment() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COMMENT, in.getComment());
+            builder.prop(DiSchemaConstants.TALEND6_COMMENT, in.getComment());
         }
         if (in.getLabel() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_LABEL, in.getLabel());
+            builder.prop(DiSchemaConstants.TALEND6_LABEL, in.getLabel());
         }
         for (TaggedValue tv : in.getTaggedValue()) {
-            if (Talend6SchemaConstants.TALEND6_IS_READ_ONLY.equals(tv.getTag())) {
-                builder.prop(Talend6SchemaConstants.TALEND6_IS_READ_ONLY, tv.getValue());
+            if (DiSchemaConstants.TALEND6_IS_READ_ONLY.equals(tv.getTag())) {
+                builder.prop(DiSchemaConstants.TALEND6_IS_READ_ONLY, tv.getValue());
                 break;
             }
         }
@@ -110,16 +108,16 @@ public final class MetadataToolAvroHelper {
         // for (TaggedValue tv : in.getTaggedValue()) {
         // String additionalTag = tv.getTag();
         // if (tv.getValue() != null) {
-        // builder.prop(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES + additionalTag, tv.getValue());
+        // builder.prop(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES + additionalTag, tv.getValue());
         // }
         // }
 
         // Table-specific properties.
         if (in.getName() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_TABLE_NAME, in.getName());
+            builder.prop(DiSchemaConstants.TALEND6_TABLE_NAME, in.getName());
         }
         if (in.getTableType() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_TABLE_TYPE, in.getTableType());
+            builder.prop(DiSchemaConstants.TALEND6_TABLE_TYPE, in.getTableType());
         }
 
         return builder;
@@ -145,42 +143,42 @@ public final class MetadataToolAvroHelper {
         Schema type = null;
         // Numeric types.
         if (JavaTypesManager.LONG.getId().equals(tt)) {
-            type = AvroTypes._long();
-            defaultValue = StringUtils.isEmpty((String)defaultValue) ? null : Long.parseLong(defaultValue.toString());
+            type = AvroUtils._long();
+            defaultValue = StringUtils.isEmpty((String) defaultValue) ? null : Long.parseLong(defaultValue.toString());
         } else if (JavaTypesManager.INTEGER.getId().equals(tt)) {
-            type = AvroTypes._int();
-            defaultValue = StringUtils.isEmpty((String)defaultValue) ? null : Integer.parseInt(defaultValue.toString());
+            type = AvroUtils._int();
+            defaultValue = StringUtils.isEmpty((String) defaultValue) ? null : Integer.parseInt(defaultValue.toString());
         } else if (JavaTypesManager.SHORT.getId().equals(tt)) {
-            type = AvroTypes._short();
-            defaultValue = StringUtils.isEmpty((String)defaultValue) ? null : Integer.parseInt(defaultValue.toString());
+            type = AvroUtils._short();
+            defaultValue = StringUtils.isEmpty((String) defaultValue) ? null : Integer.parseInt(defaultValue.toString());
         } else if (JavaTypesManager.BYTE.getId().equals(tt)) {
-            type = AvroTypes._byte();
-            defaultValue = StringUtils.isEmpty((String)defaultValue) ? null : Integer.parseInt(defaultValue.toString());
+            type = AvroUtils._byte();
+            defaultValue = StringUtils.isEmpty((String) defaultValue) ? null : Integer.parseInt(defaultValue.toString());
         } else if (JavaTypesManager.DOUBLE.getId().equals(tt)) {
-            type = AvroTypes._double();
-            defaultValue = StringUtils.isEmpty((String)defaultValue) ? null : Double.parseDouble(defaultValue.toString());
+            type = AvroUtils._double();
+            defaultValue = StringUtils.isEmpty((String) defaultValue) ? null : Double.parseDouble(defaultValue.toString());
         } else if (JavaTypesManager.FLOAT.getId().equals(tt)) {
-            type = AvroTypes._float();
-            defaultValue = StringUtils.isEmpty((String)defaultValue) ? null : Float.parseFloat(defaultValue.toString());
+            type = AvroUtils._float();
+            defaultValue = StringUtils.isEmpty((String) defaultValue) ? null : Float.parseFloat(defaultValue.toString());
         } else if (JavaTypesManager.BIGDECIMAL.getId().equals(tt)) {
             // decimal(precision, scale) == column length and precision?
-            type = AvroTypes._decimal();
+            type = AvroUtils._decimal();
         }
 
         // Other primitive types that map directly to Avro.
         else if (JavaTypesManager.BOOLEAN.getId().equals(tt)) {
-            type = AvroTypes._boolean();
-            defaultValue = StringUtils.isEmpty((String)defaultValue) ? null : Boolean.parseBoolean(defaultValue.toString());
+            type = AvroUtils._boolean();
+            defaultValue = StringUtils.isEmpty((String) defaultValue) ? null : Boolean.parseBoolean(defaultValue.toString());
         } else if (JavaTypesManager.BYTE_ARRAY.getId().equals(tt)) {
-            type = AvroTypes._bytes();
+            type = AvroUtils._bytes();
         } else if (JavaTypesManager.DATE.getId().equals(tt)) {
-            type = AvroTypes._date();
+            type = AvroUtils._date();
         }
         // String-ish types.
         else if (JavaTypesManager.STRING.getId().equals(tt) || JavaTypesManager.FILE.getId().equals(tt)
                 || JavaTypesManager.DIRECTORY.getId().equals(tt) || JavaTypesManager.VALUE_LIST.getId().equals(tt)
                 || JavaTypesManager.CHARACTER.getId().equals(tt) || JavaTypesManager.PASSWORD.getId().equals(tt)) {
-            type = AvroTypes._string();
+            type = AvroUtils._string();
         }
 
         // Types with unknown elements, store as binary
@@ -204,22 +202,22 @@ public final class MetadataToolAvroHelper {
             org.talend.core.model.metadata.builder.connection.MetadataColumn in) {
         Map<String, String> props = new HashMap<String, String>();
         if (in.getId() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_ID, in.getId());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_ID, in.getId());
         }
         if (in.getComment() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_COMMENT, in.getComment());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_COMMENT, in.getComment());
         }
         if (in.getLabel() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_NAME, in.getLabel());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_NAME, in.getLabel());
         }
 
         for (TaggedValue tv : in.getTaggedValue()) {
-            if (Talend6SchemaConstants.TALEND6_IS_READ_ONLY.equals(tv.getTag())) {
-                schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_IS_READ_ONLY, tv.getValue()); //$NON-NLS-1$
+            if (DiSchemaConstants.TALEND6_IS_READ_ONLY.equals(tv.getTag())) {
+                schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_IS_READ_ONLY, tv.getValue());
             } else {
                 String additionalTag = tv.getTag();
                 if (tv.getValue() != null) {
-                    schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_ADDITIONAL_PROPERTIES
+                    schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_ADDITIONAL_PROPERTIES
                             + additionalTag, tv.getValue());
                 }
             }
@@ -227,49 +225,46 @@ public final class MetadataToolAvroHelper {
 
         // Column-specific properties.
         if (in.isKey()) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_IS_KEY, "true"); //$NON-NLS-1$
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_IS_KEY, "true"); //$NON-NLS-1$
         }
         if (in.getType() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_SOURCE_TYPE, in.getSourceType());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_SOURCE_TYPE, in.getSourceType());
         }
         if (in.getTalendType() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE, in.getTalendType());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE, in.getTalendType());
         }
         if (in.getPattern() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_PATTERN,
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_PATTERN,
                     TalendQuoteUtils.removeQuotesIfExist(in.getPattern()));
         }
         if (in.getLength() >= 0) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_LENGTH,
-                    String.valueOf((int) in.getLength()));
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_LENGTH, String.valueOf((int) in.getLength()));
         }
         if (in.getOriginalLength() >= 0) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH,
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH,
                     String.valueOf(in.getOriginalLength()));
         }
         if (in.isNullable()) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_IS_NULLABLE, "true"); //$NON-NLS-1$
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_IS_NULLABLE, "true"); //$NON-NLS-1$
         }
         if (in.getPrecision() >= 0) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_PRECISION,
-                    String.valueOf(in.getPrecision()));
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_PRECISION, String.valueOf(in.getPrecision()));
         }
         if (in.getScale() >= 0) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_SCALE, String.valueOf(in.getScale()));
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_SCALE, String.valueOf(in.getScale()));
         }
         if (in.getInitialValue() != null && in.getInitialValue().getBody() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_DEFAULT, in.getInitialValue().getBody());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_DEFAULT, in.getInitialValue().getBody());
         }
         if (in.getName() != null) {
             // keyword fixes?
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME, in.getName());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME, in.getName());
         }
         if (in.getRelatedEntity() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_RELATED_ENTITY, in.getRelatedEntity());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_RELATED_ENTITY, in.getRelatedEntity());
         }
         if (in.getRelationshipType() != null) {
-            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE,
-                    in.getRelationshipType());
+            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE, in.getRelationshipType());
         }
         return schema;
     }
@@ -285,61 +280,60 @@ public final class MetadataToolAvroHelper {
             org.talend.core.model.metadata.builder.connection.MetadataColumn in) {
         // Properties common to tables and columns.
         if (in.getId() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_ID, in.getId());
+            builder.prop(DiSchemaConstants.TALEND6_ID, in.getId());
         }
         if (in.getComment() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COMMENT, in.getComment());
+            builder.prop(DiSchemaConstants.TALEND6_COMMENT, in.getComment());
         }
         if (in.getLabel() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_LABEL, in.getLabel());
+            builder.prop(DiSchemaConstants.TALEND6_LABEL, in.getLabel());
         }
         for (TaggedValue tv : in.getTaggedValue()) {
             String additionalTag = tv.getTag();
-            if (Talend6SchemaConstants.TALEND6_IS_READ_ONLY.equals(additionalTag)) {
-                builder.prop(Talend6SchemaConstants.TALEND6_IS_READ_ONLY, tv.getValue());
-            } else
-            if (tv.getValue() != null) {
-                builder.prop(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES + additionalTag, tv.getValue());
+            if (DiSchemaConstants.TALEND6_IS_READ_ONLY.equals(additionalTag)) {
+                builder.prop(DiSchemaConstants.TALEND6_IS_READ_ONLY, tv.getValue());
+            } else if (tv.getValue() != null) {
+                builder.prop(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES + additionalTag, tv.getValue());
             }
         }
 
         // Column-specific properties.
         if (in.isKey()) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_IS_KEY, "true"); //$NON-NLS-1$
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_IS_KEY, "true"); //$NON-NLS-1$
         }
         if (in.getType() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_SOURCE_TYPE, in.getSourceType());
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_SOURCE_TYPE, in.getSourceType());
         }
         if (in.getTalendType() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE, in.getTalendType());
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE, in.getTalendType());
         }
         if (in.getPattern() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_PATTERN, TalendQuoteUtils.removeQuotesIfExist(in.getPattern()));
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_PATTERN, TalendQuoteUtils.removeQuotesIfExist(in.getPattern()));
         }
         if (in.getLength() >= 0) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_LENGTH, String.valueOf((int) in.getLength()));
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_LENGTH, String.valueOf((int) in.getLength()));
         }
         if (in.getOriginalLength() >= 0) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH, String.valueOf(in.getOriginalLength()));
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH, String.valueOf(in.getOriginalLength()));
         }
         if (in.isNullable()) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_IS_NULLABLE, "true"); //$NON-NLS-1$
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_IS_NULLABLE, "true"); //$NON-NLS-1$
         }
         if (in.getPrecision() >= 0) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_PRECISION, String.valueOf(in.getPrecision()));
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_PRECISION, String.valueOf(in.getPrecision()));
         }
         if (in.getInitialValue() != null && in.getInitialValue().getBody() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_DEFAULT, in.getInitialValue().getBody());
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_DEFAULT, in.getInitialValue().getBody());
         }
         if (in.getName() != null) {
             // keyword fixes?
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME, in.getName());
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME, in.getName());
         }
         if (in.getRelatedEntity() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_RELATED_ENTITY, in.getRelatedEntity());
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_RELATED_ENTITY, in.getRelatedEntity());
         }
         if (in.getRelationshipType() != null) {
-            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE, in.getRelationshipType());
+            builder.prop(DiSchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE, in.getRelationshipType());
         }
         return builder;
     }
@@ -362,32 +356,32 @@ public final class MetadataToolAvroHelper {
 
         // Properties common to tables and columns.
         String prop;
-        if (null != (prop = in.getProp(Talend6SchemaConstants.TALEND6_ID))) {
+        if (null != (prop = in.getProp(DiSchemaConstants.TALEND6_ID))) {
             table.setId(prop);
         }
-        if (null != (prop = in.getProp(Talend6SchemaConstants.TALEND6_COMMENT))) {
-            table.setComment(in.getProp(Talend6SchemaConstants.TALEND6_ID));
+        if (null != (prop = in.getProp(DiSchemaConstants.TALEND6_COMMENT))) {
+            table.setComment(in.getProp(DiSchemaConstants.TALEND6_ID));
         }
-        if (null != (prop = in.getProp(Talend6SchemaConstants.TALEND6_LABEL))) {
-            table.setLabel(in.getProp(Talend6SchemaConstants.TALEND6_LABEL));
+        if (null != (prop = in.getProp(DiSchemaConstants.TALEND6_LABEL))) {
+            table.setLabel(in.getProp(DiSchemaConstants.TALEND6_LABEL));
         }
-        if (null != (prop = in.getProp(Talend6SchemaConstants.TALEND6_IS_READ_ONLY))) {
-            TaggedValue tv = TaggedValueHelper.createTaggedValue(Talend6SchemaConstants.TALEND6_IS_READ_ONLY, prop);
+        if (null != (prop = in.getProp(DiSchemaConstants.TALEND6_IS_READ_ONLY))) {
+            TaggedValue tv = TaggedValueHelper.createTaggedValue(DiSchemaConstants.TALEND6_IS_READ_ONLY, prop);
             table.getTaggedValue().add(tv);
         }
         for (String key : in.getJsonProps().keySet()) {
-            if (key.startsWith(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES)) {
-                String originalKey = key.substring(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES.length());
+            if (key.startsWith(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES)) {
+                String originalKey = key.substring(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES.length());
                 TaggedValue tv = TaggedValueHelper.createTaggedValue(originalKey, in.getProp(key));
                 table.getTaggedValue().add(tv);
             }
         }
 
         // Table-specific properties.
-        if (null != (prop = in.getProp(Talend6SchemaConstants.TALEND6_TABLE_NAME))) {
+        if (null != (prop = in.getProp(DiSchemaConstants.TALEND6_TABLE_NAME))) {
             table.setName(prop);
         }
-        if (null != (prop = in.getProp(Talend6SchemaConstants.TALEND6_TABLE_TYPE))) {
+        if (null != (prop = in.getProp(DiSchemaConstants.TALEND6_TABLE_TYPE))) {
             table.setTableType(prop);
         }
 
@@ -400,7 +394,7 @@ public final class MetadataToolAvroHelper {
         if (isDynamic) {
             org.talend.core.model.metadata.builder.connection.MetadataColumn col = convertFromAvroForDynamic(in);
             // get dynamic position
-            int dynPosition = Integer.valueOf(in.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION));
+            int dynPosition = Integer.valueOf(in.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION));
             columns.add(dynPosition, col);
         }
         table.getColumns().addAll(columns);
@@ -410,74 +404,74 @@ public final class MetadataToolAvroHelper {
     public static org.talend.core.model.metadata.builder.connection.MetadataColumn convertFromAvroForDynamic(Schema schema) {
         org.talend.core.model.metadata.builder.connection.MetadataColumn col = ConnectionFactory.eINSTANCE.createMetadataColumn();
         String prop;
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_ID))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_ID))) {
             col.setId(prop);
         }
 
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_COMMENT))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_COMMENT))) {
             col.setComment(prop);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_NAME))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_NAME))) {
             col.setLabel(prop);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_IS_READ_ONLY))) {
-            TaggedValue tv = TaggedValueHelper.createTaggedValue(Talend6SchemaConstants.TALEND6_IS_READ_ONLY, prop);
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_DYNAMIC_IS_READ_ONLY))) {
+            TaggedValue tv = TaggedValueHelper.createTaggedValue(DiSchemaConstants.TALEND6_IS_READ_ONLY, prop);
             col.getTaggedValue().add(tv);
         }
         for (String key : schema.getJsonProps().keySet()) {
-            if (key.startsWith(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES)) {
-                String originalKey = key.substring(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES.length());
+            if (key.startsWith(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES)) {
+                String originalKey = key.substring(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES.length());
                 TaggedValue tv = TaggedValueHelper.createTaggedValue(originalKey, schema.getProp(key));
                 col.getTaggedValue().add(tv);
             }
         }
 
         // Column-specific properties.
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_IS_KEY))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_IS_KEY))) {
             col.setKey(Boolean.parseBoolean(prop));
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_SOURCE_TYPE))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_SOURCE_TYPE))) {
             col.setSourceType(prop);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE))) {
             col.setTalendType(prop);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_PATTERN))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_PATTERN))) {
             if (!StringUtils.isEmpty(prop)) {
                 col.setPattern(TalendQuoteUtils.addQuotesIfNotExist(prop));
             }
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_LENGTH))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_LENGTH))) {
             Long value = Long.parseLong(prop);
             col.setLength(value >= 0 ? value : -1);
         } else {
             col.setLength(-1);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH))) {
             Long value = Long.parseLong(prop);
             col.setOriginalLength(value >= 0 ? value : -1);
         } else {
             col.setOriginalLength(-1);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_IS_NULLABLE))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_IS_NULLABLE))) {
             col.setNullable(Boolean.parseBoolean(prop));
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_PRECISION))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_PRECISION))) {
             Long value = Long.parseLong(prop);
             col.setPrecision(value >= 0 ? value : -1);
         } else {
             col.setPrecision(-1);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_DEFAULT))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_DEFAULT))) {
             col.setDefaultValue(prop);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME))) {
             col.setName(prop);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_RELATED_ENTITY))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_RELATED_ENTITY))) {
             col.setRelatedEntity(prop);
         }
-        if (null != (prop = schema.getProp(Talend6SchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE))) {
+        if (null != (prop = schema.getProp(DiSchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE))) {
             col.setRelationshipType(prop);
         }
 
@@ -499,29 +493,29 @@ public final class MetadataToolAvroHelper {
         col.setLabel(field.name());
         col.setName(field.name());
         Schema nonnullable = AvroUtils.unwrapIfNullable(in);
-        if (AvroTypes.isSameType(nonnullable, AvroTypes._boolean())) {
+        if (AvroUtils.isSameType(nonnullable, AvroUtils._boolean())) {
             col.setTalendType(JavaTypesManager.BOOLEAN.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._byte())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._byte())) {
             col.setTalendType(JavaTypesManager.BYTE.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._bytes())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._bytes())) {
             col.setTalendType(JavaTypesManager.BYTE_ARRAY.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._character())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._character())) {
             col.setTalendType(JavaTypesManager.CHARACTER.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._date())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._date())) {
             col.setTalendType(JavaTypesManager.DATE.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._decimal())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._decimal())) {
             col.setTalendType(JavaTypesManager.BIGDECIMAL.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._double())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._double())) {
             col.setTalendType(JavaTypesManager.DOUBLE.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._float())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._float())) {
             col.setTalendType(JavaTypesManager.FLOAT.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._int())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._int())) {
             col.setTalendType(JavaTypesManager.INTEGER.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._long())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._long())) {
             col.setTalendType(JavaTypesManager.LONG.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._short())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._short())) {
             col.setTalendType(JavaTypesManager.SHORT.getId());
-        } else if (AvroTypes.isSameType(nonnullable, AvroTypes._string())) {
+        } else if (AvroUtils.isSameType(nonnullable, AvroUtils._string())) {
             col.setTalendType(JavaTypesManager.STRING.getId());
         }
         // FIXME missing List and Object here
@@ -533,83 +527,83 @@ public final class MetadataToolAvroHelper {
 
         // Properties common to tables and columns.
         String prop;
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_ID))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_ID))) {
             col.setId(prop);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COMMENT))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COMMENT))) {
             col.setComment(prop);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_LABEL))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_LABEL))) {
             col.setLabel(prop);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_IS_READ_ONLY))) {
-            TaggedValue tv = TaggedValueHelper.createTaggedValue(Talend6SchemaConstants.TALEND6_IS_READ_ONLY, prop);
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_IS_READ_ONLY))) {
+            TaggedValue tv = TaggedValueHelper.createTaggedValue(DiSchemaConstants.TALEND6_IS_READ_ONLY, prop);
             col.getTaggedValue().add(tv);
         }
         for (String key : field.getJsonProps().keySet()) {
-            if (key.startsWith(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES)) {
-                String originalKey = key.substring(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES.length());
+            if (key.startsWith(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES)) {
+                String originalKey = key.substring(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES.length());
                 TaggedValue tv = TaggedValueHelper.createTaggedValue(originalKey, field.getProp(key));
                 col.getTaggedValue().add(tv);
             }
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_CUSTOM))) {
-            TaggedValue tv = TaggedValueHelper.createTaggedValue(Talend6SchemaConstants.TALEND6_COLUMN_CUSTOM, prop);
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_CUSTOM))) {
+            TaggedValue tv = TaggedValueHelper.createTaggedValue(DiSchemaConstants.TALEND6_COLUMN_CUSTOM, prop);
             col.getTaggedValue().add(tv);
         }
 
         // Column-specific properties.
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_IS_KEY))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_IS_KEY))) {
             col.setKey(Boolean.parseBoolean(prop));
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_SOURCE_TYPE))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_SOURCE_TYPE))) {
             col.setSourceType(prop);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE))) {
             col.setTalendType(prop);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_PATTERN))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_PATTERN))) {
             if (!StringUtils.isEmpty(prop)) {
                 col.setPattern(TalendQuoteUtils.addQuotesIfNotExist(prop));
             }
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_LENGTH))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_LENGTH))) {
             Long value = Long.parseLong(prop);
             col.setLength(value >= 0 ? value : -1);
         } else {
             col.setLength(-1);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH))) {
             Long value = Long.parseLong(prop);
             col.setOriginalLength(value >= 0 ? value : -1);
         } else {
             col.setOriginalLength(-1);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_IS_NULLABLE))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_IS_NULLABLE))) {
             col.setNullable(Boolean.parseBoolean(prop));
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_PRECISION))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_PRECISION))) {
             Long value = Long.parseLong(prop);
             col.setPrecision(value >= 0 ? value : -1);
         } else {
             col.setPrecision(-1);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_SCALE))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_SCALE))) {
             Long value = Long.parseLong(prop);
             col.setScale(value >= 0 ? value : -1);
         } else {
             col.setScale(-1);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_DEFAULT))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_DEFAULT))) {
             col.setDefaultValue(prop);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME))) {
             col.setName(prop);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_RELATED_ENTITY))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_RELATED_ENTITY))) {
             col.setRelatedEntity(prop);
         }
-        if (null != (prop = field.getProp(Talend6SchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE))) {
+        if (null != (prop = field.getProp(DiSchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE))) {
             col.setRelationshipType(prop);
         }
 
@@ -648,7 +642,7 @@ public final class MetadataToolAvroHelper {
     // // store all the dynamic column's properties
     // schema = copyDynamicColumnProperties(schema, dynColumn);
     // // store dynamic position
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION,
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION,
     // String.valueOf(dynamicPosition));
     // // tag avro schema with include-all-columns
     // schema = AvroUtils.setIncludeAllFields(schema, true);
@@ -670,24 +664,24 @@ public final class MetadataToolAvroHelper {
     //
     // // FIXME: I comment it. I think there is no need to care id.
     // // if (in.getId() != null) {
-    // // builder.prop(Talend6SchemaConstants.TALEND6_ID, in.getId());
+    // // builder.prop(DiSchemaConstants.TALEND6_ID, in.getId());
     // // }
     // if (in.getComment() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COMMENT, in.getComment());
+    // builder.prop(DiSchemaConstants.TALEND6_COMMENT, in.getComment());
     // }
     // if (in.getLabel() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_LABEL, in.getLabel());
+    // builder.prop(DiSchemaConstants.TALEND6_LABEL, in.getLabel());
     // }
     // if (in.isReadOnly()) {
-    //            builder.prop(Talend6SchemaConstants.TALEND6_IS_READ_ONLY, "true"); //$NON-NLS-1$
+    //            builder.prop(DiSchemaConstants.TALEND6_IS_READ_ONLY, "true"); //$NON-NLS-1$
     // }
     //
     // // Table-specific properties.
     // if (in.getTableName() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_TABLE_NAME, in.getTableName());
+    // builder.prop(DiSchemaConstants.TALEND6_TABLE_NAME, in.getTableName());
     // }
     // if (in.getTableType() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_TABLE_TYPE, in.getTableType());
+    // builder.prop(DiSchemaConstants.TALEND6_TABLE_TYPE, in.getTableType());
     // }
     //
     // return builder;
@@ -708,42 +702,42 @@ public final class MetadataToolAvroHelper {
     // Schema type = null;
     // // Numeric types.
     // if (JavaTypesManager.LONG.getId().equals(tt)) {
-    // type = AvroTypes._long();
+    // type = AvroUtils._long();
     // defaultValue = defaultValue == null ? null : Long.parseLong(defaultValue.toString());
     // } else if (JavaTypesManager.INTEGER.getId().equals(tt)) {
-    // type = AvroTypes._int();
+    // type = AvroUtils._int();
     // defaultValue = defaultValue == null ? null : Integer.parseInt(defaultValue.toString());
     // } else if (JavaTypesManager.SHORT.getId().equals(tt)) {
-    // type = AvroTypes._short();
+    // type = AvroUtils._short();
     // defaultValue = defaultValue == null ? null : Integer.parseInt(defaultValue.toString());
     // } else if (JavaTypesManager.BYTE.getId().equals(tt)) {
-    // type = AvroTypes._byte();
+    // type = AvroUtils._byte();
     // defaultValue = defaultValue == null ? null : Integer.parseInt(defaultValue.toString());
     // } else if (JavaTypesManager.DOUBLE.getId().equals(tt)) {
-    // type = AvroTypes._double();
+    // type = AvroUtils._double();
     // defaultValue = defaultValue == null ? null : Double.parseDouble(defaultValue.toString());
     // } else if (JavaTypesManager.FLOAT.getId().equals(tt)) {
-    // type = AvroTypes._float();
+    // type = AvroUtils._float();
     // defaultValue = defaultValue == null ? null : Float.parseFloat(defaultValue.toString());
     // } else if (JavaTypesManager.BIGDECIMAL.getId().equals(tt)) {
     // // decimal(precision, scale) == column length and precision?
-    // type = AvroTypes._decimal();
+    // type = AvroUtils._decimal();
     // }
     //
     // // Other primitive types that map directly to Avro.
     // else if (JavaTypesManager.BOOLEAN.getId().equals(tt)) {
-    // type = AvroTypes._boolean();
+    // type = AvroUtils._boolean();
     // defaultValue = defaultValue == null ? null : Boolean.parseBoolean(defaultValue.toString());
     // } else if (JavaTypesManager.BYTE_ARRAY.getId().equals(tt)) {
-    // type = AvroTypes._bytes();
+    // type = AvroUtils._bytes();
     // } else if (JavaTypesManager.DATE.getId().equals(tt)) {
-    // type = AvroTypes._date();
+    // type = AvroUtils._date();
     // }
     // // String-ish types.
     // else if (JavaTypesManager.STRING.getId().equals(tt) || JavaTypesManager.FILE.getId().equals(tt)
     // || JavaTypesManager.DIRECTORY.getId().equals(tt) || JavaTypesManager.VALUE_LIST.getId().equals(tt)
     // || JavaTypesManager.CHARACTER.getId().equals(tt) || JavaTypesManager.PASSWORD.getId().equals(tt)) {
-    // type = AvroTypes._string();
+    // type = AvroUtils._string();
     // }
     //
     // // Types with unknown elements, store as binary
@@ -774,63 +768,63 @@ public final class MetadataToolAvroHelper {
     // IMetadataColumn in) {
     // // Properties common to tables and columns.
     // if (in.getId() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_ID, in.getId());
+    // builder.prop(DiSchemaConstants.TALEND6_ID, in.getId());
     // }
     // if (in.getComment() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COMMENT, in.getComment());
+    // builder.prop(DiSchemaConstants.TALEND6_COMMENT, in.getComment());
     // }
     // if (in.getLabel() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_LABEL, in.getLabel());
+    // builder.prop(DiSchemaConstants.TALEND6_LABEL, in.getLabel());
     // }
     // if (in.isReadOnly()) {
-    //            builder.prop(Talend6SchemaConstants.TALEND6_IS_READ_ONLY, "true"); //$NON-NLS-1$
+    //            builder.prop(DiSchemaConstants.TALEND6_IS_READ_ONLY, "true"); //$NON-NLS-1$
     // }
     // // no such support for IMetadataColumn
     // //
     // // for (TaggedValue tv : in.getTaggedValue()) {
     // // String additionalTag = tv.getTag();
     // // if (tv.getValue() != null) {
-    // // builder.prop(Talend6SchemaConstants.TALEND6_ADDITIONAL_PROPERTIES + additionalTag, tv.getValue());
+    // // builder.prop(DiSchemaConstants.TALEND6_ADDITIONAL_PROPERTIES + additionalTag, tv.getValue());
     // // }
     // // }
     //
     // // Column-specific properties.
     // if (in.isKey()) {
-    //            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_IS_KEY, "true"); //$NON-NLS-1$
+    //            builder.prop(DiSchemaConstants.TALEND6_COLUMN_IS_KEY, "true"); //$NON-NLS-1$
     // }
     // if (in.getType() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_SOURCE_TYPE, in.getType());
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_SOURCE_TYPE, in.getType());
     // }
     // if (in.getTalendType() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE, in.getTalendType());
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE, in.getTalendType());
     // }
     // if (in.getPattern() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_PATTERN,
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_PATTERN,
     // TalendQuoteUtils.removeQuotesIfExist(in.getPattern()));
     // }
     // if (in.getLength() != null && in.getLength() >= 0) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_LENGTH, String.valueOf((int) in.getLength()));
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_LENGTH, String.valueOf((int) in.getLength()));
     // }
     // if (in.getOriginalLength() != null && in.getOriginalLength() >= 0) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH, String.valueOf(in.getOriginalLength()));
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH, String.valueOf(in.getOriginalLength()));
     // }
     // if (in.isNullable()) {
-    //            builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_IS_NULLABLE, "true"); //$NON-NLS-1$
+    //            builder.prop(DiSchemaConstants.TALEND6_COLUMN_IS_NULLABLE, "true"); //$NON-NLS-1$
     // }
     // if (in.getPrecision() != null && in.getPrecision() >= 0) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_PRECISION, String.valueOf(in.getPrecision()));
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_PRECISION, String.valueOf(in.getPrecision()));
     // }
     // if (in.getDefault() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_DEFAULT, in.getDefault());
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_DEFAULT, in.getDefault());
     // }
     // if (in.getOriginalDbColumnName() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME, in.getOriginalDbColumnName());
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME, in.getOriginalDbColumnName());
     // }
     // if (in.getRelatedEntity() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_RELATED_ENTITY, in.getRelatedEntity());
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_RELATED_ENTITY, in.getRelatedEntity());
     // }
     // if (in.getRelationshipType() != null) {
-    // builder.prop(Talend6SchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE, in.getRelationshipType());
+    // builder.prop(DiSchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE, in.getRelationshipType());
     // }
     // return builder;
     // }
@@ -839,61 +833,61 @@ public final class MetadataToolAvroHelper {
     // IMetadataColumn in) {
     // Map<String, String> props = new HashMap<String, String>();
     // if (in.getId() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_ID, in.getId());
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_ID, in.getId());
     // }
     // if (in.getComment() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_COMMENT, in.getComment());
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_COMMENT, in.getComment());
     // }
     // if (in.getLabel() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_NAME, in.getLabel());
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_NAME, in.getLabel());
     // }
     // if (in.isReadOnly()) {
-    //            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_DYNAMIC_IS_READ_ONLY, "true"); //$NON-NLS-1$
+    //            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_DYNAMIC_IS_READ_ONLY, "true"); //$NON-NLS-1$
     // }
     //
     // // Column-specific properties.
     // if (in.isKey()) {
-    //            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_IS_KEY, "true"); //$NON-NLS-1$
+    //            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_IS_KEY, "true"); //$NON-NLS-1$
     // }
     // if (in.getType() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_SOURCE_TYPE, in.getType());
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_SOURCE_TYPE, in.getType());
     // }
     // if (in.getTalendType() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE, in.getTalendType());
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE, in.getTalendType());
     // }
     // if (in.getPattern() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_PATTERN,
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_PATTERN,
     // TalendQuoteUtils.removeQuotesIfExist(in.getPattern()));
     // }
     // if (in.getLength() >= 0) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_LENGTH,
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_LENGTH,
     // String.valueOf((int) in.getLength()));
     // }
     // if (in.getOriginalLength() >= 0) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH,
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_LENGTH,
     // String.valueOf(in.getOriginalLength()));
     // }
     // if (in.isNullable()) {
-    //            schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_IS_NULLABLE, "true"); //$NON-NLS-1$
+    //            schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_IS_NULLABLE, "true"); //$NON-NLS-1$
     // }
     // if (in.getPrecision() >= 0) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_PRECISION,
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_PRECISION,
     // String.valueOf(in.getPrecision()));
     // }
     // if (in.getDefault() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_DEFAULT, in.getDefault());
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_DEFAULT, in.getDefault());
     // }
     // if (in.getOriginalDbColumnName() != null) {
     // // keyword fixes?
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME,
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME,
     // in.getOriginalDbColumnName());
     // }
     // if (in.getRelatedEntity() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_RELATED_ENTITY,
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_RELATED_ENTITY,
     // in.getRelatedEntity());
     // }
     // if (in.getRelationshipType() != null) {
-    // schema = AvroUtils.setProperty(schema, Talend6SchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE,
+    // schema = AvroUtils.setProperty(schema, DiSchemaConstants.TALEND6_COLUMN_RELATIONSHIP_TYPE,
     // in.getRelationshipType());
     // }
     // return schema;

--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/metadata/MetadataToolHelper.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/metadata/MetadataToolHelper.java
@@ -73,14 +73,13 @@ import org.talend.core.runtime.i18n.Messages;
 import org.talend.core.runtime.services.IGenericWizardService;
 import org.talend.core.utils.KeywordsValidator;
 import org.talend.cwm.helper.ConnectionHelper;
-import org.talend.daikon.talend6.Talend6SchemaConstants;
+import org.talend.daikon.di.DiSchemaConstants;
 import org.talend.designer.core.model.utils.emf.talendfile.ColumnType;
 import org.talend.designer.core.model.utils.emf.talendfile.MetadataType;
 import org.talend.designer.core.model.utils.emf.talendfile.TalendFileFactory;
 import org.talend.repository.model.IProxyRepositoryFactory;
 import org.talend.repository.model.IRepositoryService;
 import org.talend.repository.model.RepositoryConstants;
-
 import orgomg.cwm.objectmodel.core.TaggedValue;
 
 /**
@@ -1353,7 +1352,7 @@ public final class MetadataToolHelper {
         result.setTableName(sourceName);
         List<IMetadataColumn> columns = new ArrayList<IMetadataColumn>(old.getColumns().size());
         for (TaggedValue tv : old.getTaggedValue()) {
-            if (Talend6SchemaConstants.TALEND6_IS_READ_ONLY.equals(tv.getTag())) {
+            if (DiSchemaConstants.TALEND6_IS_READ_ONLY.equals(tv.getTag())) {
                 result.setReadOnly(Boolean.valueOf(tv.getValue()));
                 break;
             }
@@ -1392,9 +1391,9 @@ public final class MetadataToolHelper {
                         String[] splits = additionalTag.split(":");
                         additionalTag = splits[1];
                     }
-                    if (Talend6SchemaConstants.TALEND6_COLUMN_CUSTOM.equals(additionalTag)) {
+                    if (DiSchemaConstants.TALEND6_COLUMN_CUSTOM.equals(additionalTag)) {
                         newColumn.setCustom(Boolean.valueOf(tv.getValue()));
-                    } else if (Talend6SchemaConstants.TALEND6_IS_READ_ONLY.equals(additionalTag)) {
+                    } else if (DiSchemaConstants.TALEND6_IS_READ_ONLY.equals(additionalTag)) {
                         newColumn.setReadOnly(Boolean.valueOf(tv.getValue()));
                     } else {
                         newColumn.getAdditionalField().put(additionalTag, tv.getValue());

--- a/test/plugins/org.talend.core.runtime.test/src/org/talend/core/model/metadata/MetadataToolAvroHelperTest.java
+++ b/test/plugins/org.talend.core.runtime.test/src/org/talend/core/model/metadata/MetadataToolAvroHelperTest.java
@@ -28,10 +28,9 @@ import org.junit.Test;
 import org.talend.core.model.metadata.builder.connection.ConnectionFactory;
 import org.talend.core.model.metadata.builder.connection.MetadataTable;
 import org.talend.core.model.metadata.types.JavaTypesManager;
+import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.SchemaConstants;
-import org.talend.daikon.avro.util.AvroTypes;
-import org.talend.daikon.avro.util.AvroUtils;
-import org.talend.daikon.talend6.Talend6SchemaConstants;
+import org.talend.daikon.di.DiSchemaConstants;
 
 /**
  * DOC hwang class global comment. Detailled comment <br/>
@@ -93,62 +92,62 @@ public class MetadataToolAvroHelperTest {
         assertThat(s.getName(), is("testTable"));
         assertThat(s.getFields().size(), is(3));
         // assertThat(s.getObjectProps().keySet(),
-        // contains(Talend6SchemaConstants.TALEND6_LABEL, Talend6SchemaConstants.TALEND6_COMMENT));
-        assertThat(s.getProp(Talend6SchemaConstants.TALEND6_LABEL), is("testTable"));
-        assertThat(s.getProp(Talend6SchemaConstants.TALEND6_COMMENT), is("A comment about this table."));
+        // contains(DiSchemaConstants.TALEND6_LABEL, DiSchemaConstants.TALEND6_COMMENT));
+        assertThat(s.getProp(DiSchemaConstants.TALEND6_LABEL), is("testTable"));
+        assertThat(s.getProp(DiSchemaConstants.TALEND6_COMMENT), is("A comment about this table."));
 
         Schema.Field f = s.getFields().get(0);
         assertTrue(AvroUtils.isNullable(f.schema()));
         assertThat(AvroUtils.unwrapIfNullable(f.schema()).getType(), is(Schema.Type.INT));
         assertThat(f.name(), is("id"));
         // assertThat(s.getObjectProps().keySet(),
-        // contains(Talend6SchemaConstants.TALEND6_LABEL, Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE));
-        assertThat(f.getProp(Talend6SchemaConstants.TALEND6_LABEL), is("id"));
-        assertThat(f.getProp(Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE), is("id_Integer"));
+        // contains(DiSchemaConstants.TALEND6_LABEL, DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE));
+        assertThat(f.getProp(DiSchemaConstants.TALEND6_LABEL), is("id"));
+        assertThat(f.getProp(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE), is("id_Integer"));
 
         f = s.getFields().get(1);
         assertThat(f.schema().getType(), is(Schema.Type.STRING));
         assertThat(f.name(), is("name"));
         assertFalse(AvroUtils.isNullable(f.schema()));
         // assertThat(s.getObjectProps().keySet(),
-        // contains(Talend6SchemaConstants.TALEND6_LABEL, Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE));
-        assertThat(f.getProp(Talend6SchemaConstants.TALEND6_LABEL), is("name"));
-        assertThat(f.getProp(Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE), is("id_String"));
+        // contains(DiSchemaConstants.TALEND6_LABEL, DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE));
+        assertThat(f.getProp(DiSchemaConstants.TALEND6_LABEL), is("name"));
+        assertThat(f.getProp(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE), is("id_String"));
 
         f = s.getFields().get(2);
         assertThat(f.schema().getType(), is(Schema.Type.BOOLEAN));
         assertThat(f.name(), is("valid"));
         // assertThat(s.getObjectProps().keySet(),
-        // contains(Talend6SchemaConstants.TALEND6_LABEL, Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE));
-        assertThat(f.getProp(Talend6SchemaConstants.TALEND6_LABEL), is("valid"));
-        assertThat(f.getProp(Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE), is("id_Boolean"));
+        // contains(DiSchemaConstants.TALEND6_LABEL, DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE));
+        assertThat(f.getProp(DiSchemaConstants.TALEND6_LABEL), is("valid"));
+        assertThat(f.getProp(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE), is("id_Boolean"));
 
         assertThat(s.getProp(SchemaConstants.INCLUDE_ALL_FIELDS), is("true"));
-        assertThat(s.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_NAME), is("dyn"));
-        assertThat(s.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION), is("3"));
-        assertThat(s.getProp(Talend6SchemaConstants.TALEND6_COLUMN_TALEND_TYPE), is("id_Dynamic"));
+        assertThat(s.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_NAME), is("dyn"));
+        assertThat(s.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION), is("3"));
+        assertThat(s.getProp(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE), is("id_Dynamic"));
     }
 
     @Test
     public void testConvertFromAvro() {
         SortedMap<String, Schema> map = new TreeMap<>();
-        map.put(JavaTypesManager.STRING.getId(), AvroTypes._string());
-        map.put(JavaTypesManager.LONG.getId(), AvroTypes._long());
-        map.put(JavaTypesManager.INTEGER.getId(), AvroTypes._int());
-        map.put(JavaTypesManager.SHORT.getId(), AvroTypes._short());
-        map.put(JavaTypesManager.BYTE.getId(), AvroTypes._byte());
-        map.put(JavaTypesManager.DOUBLE.getId(), AvroTypes._double());
-        map.put(JavaTypesManager.FLOAT.getId(), AvroTypes._float());
-        map.put(JavaTypesManager.BIGDECIMAL.getId(), AvroTypes._decimal());
-        map.put(JavaTypesManager.BOOLEAN.getId(), AvroTypes._boolean());
-        map.put(JavaTypesManager.BYTE_ARRAY.getId(), AvroTypes._bytes());
-        map.put(JavaTypesManager.DATE.getId(), AvroTypes._date());
+        map.put(JavaTypesManager.STRING.getId(), AvroUtils._string());
+        map.put(JavaTypesManager.LONG.getId(), AvroUtils._long());
+        map.put(JavaTypesManager.INTEGER.getId(), AvroUtils._int());
+        map.put(JavaTypesManager.SHORT.getId(), AvroUtils._short());
+        map.put(JavaTypesManager.BYTE.getId(), AvroUtils._byte());
+        map.put(JavaTypesManager.DOUBLE.getId(), AvroUtils._double());
+        map.put(JavaTypesManager.FLOAT.getId(), AvroUtils._float());
+        map.put(JavaTypesManager.BIGDECIMAL.getId(), AvroUtils._decimal());
+        map.put(JavaTypesManager.BOOLEAN.getId(), AvroUtils._boolean());
+        map.put(JavaTypesManager.BYTE_ARRAY.getId(), AvroUtils._bytes());
+        map.put(JavaTypesManager.DATE.getId(), AvroUtils._date());
 
         RecordBuilder<Schema> builder = SchemaBuilder.builder().record("MyTable"); //$NON-NLS-1$
         FieldAssembler<Schema> fa = builder.fields();
         for (String talendType : map.keySet()) {
             FieldBuilder<Schema> fb = fa.name(talendType.replace('[', '_').replace(']', '_'));
-            fb.prop(Talend6SchemaConstants.TALEND6_LABEL, talendType);
+            fb.prop(DiSchemaConstants.TALEND6_LABEL, talendType);
             fa = fb.type(map.get(talendType)).noDefault();
         }
         Schema schema = fa.endRecord();


### PR DESCRIPTION
This includes the changes caused by the refactoring in TDKN-26 for when the Studio is updated to use the next versions of the component framework (0.13.0-SNAPSHOT) and daikon (0.12.0-SNAPSHOT).
