### PR TITLE
TDI-36633 fix: On "Import items" dialog standard job folder show same

### DIFF
--- a/main/plugins/org.talend.repository.items.importexport/src/main/java/org/talend/repository/items/importexport/wizard/models/ImportNodesBuilder.java
+++ b/main/plugins/org.talend.repository.items.importexport/src/main/java/org/talend/repository/items/importexport/wizard/models/ImportNodesBuilder.java
@@ -189,6 +189,7 @@ public class ImportNodesBuilder {
                     typeImportNode.addChild(standJobImportNode);
                 }
                 parentImportNode = standJobImportNode;
+                typeImportNode = standJobImportNode;
 
             }
             String path = item.getState().getPath();


### PR DESCRIPTION
on "Import items" dialog standard job folder show same level with  "Standard" node, but should under  "Standard" node
https://jira.talendforge.org/browse/TDI-36633