### PR TITLE
TUP-5859: The dbconnection is closed and recreated for many times, which

### DIFF
--- a/main/plugins/org.talend.metadata.managment/src/main/java/org/talend/core/model/metadata/builder/database/manager/ExtractManager.java
+++ b/main/plugins/org.talend.metadata.managment/src/main/java/org/talend/core/model/metadata/builder/database/manager/ExtractManager.java
@@ -374,17 +374,13 @@ public class ExtractManager {
             // metadataColumns = ExtractMetaDataFromDataBase.extractColumns(dbMetaData, newNode, metadataConnection,
             // dbType);
             ColumnSetHelper.addColumns(table, metadataColumns);
-
-            if (needCreateAndClose) {
-                extractMeta.closeConnection();
-            }
         } catch (Exception e) {
             ExceptionHandler.process(e);
             log.error(e);
         } finally {
             // bug 22619
-            if (extractMeta.getConn() != null) {
-                ConnectionUtils.closeConnection(extractMeta.getConn());
+            if (needCreateAndClose && extractMeta.getConn() != null) {
+                extractMeta.closeConnection();
             }
         }
 

--- a/main/plugins/org.talend.repository.metadata/src/main/java/org/talend/repository/ui/wizards/metadata/table/database/DatabaseTableWizard.java
+++ b/main/plugins/org.talend.repository.metadata/src/main/java/org/talend/repository/ui/wizards/metadata/table/database/DatabaseTableWizard.java
@@ -45,6 +45,7 @@ import org.talend.core.model.metadata.IMetadataTable;
 import org.talend.core.model.metadata.builder.connection.Connection;
 import org.talend.core.model.metadata.builder.connection.DatabaseConnection;
 import org.talend.core.model.metadata.builder.connection.MetadataTable;
+import org.talend.core.model.metadata.builder.database.ExtractMetaDataUtils;
 import org.talend.core.model.metadata.builder.database.TableInfoParameters;
 import org.talend.core.model.properties.ConnectionItem;
 import org.talend.core.model.repository.IRepositoryViewObject;
@@ -251,6 +252,9 @@ public class DatabaseTableWizard extends CheckLastVersionRepositoryWizard implem
 
                     oldCopiedConnection = null;
                     tableHelper.clean();
+                    if (ExtractMetaDataUtils.getInstance().getConn() != null) {
+                        ExtractMetaDataUtils.getInstance().closeConnection();
+                    }
                 }
             };
             try {


### PR DESCRIPTION
made retrieve schemas very slow.