### PR TITLE
TESB-17856: For commandline builds ESB Micorservice bundle

### DIFF
--- a/main/plugins/org.talend.commons.runtime/src/org/talend/commons/CommonsPlugin.java
+++ b/main/plugins/org.talend.commons.runtime/src/org/talend/commons/CommonsPlugin.java
@@ -48,6 +48,9 @@ public class CommonsPlugin implements BundleActivator {
 
     private static boolean isWorkbenchCreated = false;
 
+    // TESB-17856: For commandline builds ESB Micorservice bundle
+    private static boolean isESBMicorservice = false;
+
     public static boolean isWorkbenchCreated() {
         return isWorkbenchCreated;
     }
@@ -137,6 +140,14 @@ public class CommonsPlugin implements BundleActivator {
             }
         }
         return service;
+    }
+
+    public static boolean isESBMicorservice() {
+        return isESBMicorservice;
+    }
+
+    public static void setESBMicorservice(boolean isESBMicorservice) {
+        CommonsPlugin.isESBMicorservice = isESBMicorservice;
     }
 
 }

--- a/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/launch/MavenCommandLauncher.java
+++ b/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/launch/MavenCommandLauncher.java
@@ -157,7 +157,7 @@ public class MavenCommandLauncher {
             workingCopy.setAttribute(ILaunchManager.ATTR_PRIVATE, true);
             workingCopy.setAttribute(RefreshUtil.ATTR_REFRESH_SCOPE, RefreshUtil.MEMENTO_SELECTED_PROJECT);
             workingCopy.setAttribute(RefreshUtil.ATTR_REFRESH_RECURSIVE, true);
-            if (CommonsPlugin.isHeadless()) {
+            if (CommonsPlugin.isHeadless() && !CommonsPlugin.isESBMicorservice()) {
                 workingCopy.setAttribute(MavenLaunchConstants.ATTR_OFFLINE, true);
             }
 


### PR DESCRIPTION
Hi,

ESB Micorservice bundle still need maven online to build as a jar, we still not find a simple way to build this spring boot bundle iwth maven offline setting, so I added a checked in CommonsPlugin.java for the commandline builds ESB Micorservice jar, if the commandline is building ESB Micorservice, it will ignore to switch maven to offline, for any other cases, it will keep maven offline setting.

Thanks,
Yi Yan
