### PR TITLE
TUP-15968 Fix Get in a freshly install 6.1.2 Studio, this error in the

### DIFF
--- a/main/plugins/org.talend.repository.view/src/org/talend/repository/navigator/RepoViewCommonViewer.java
+++ b/main/plugins/org.talend.repository.view/src/org/talend/repository/navigator/RepoViewCommonViewer.java
@@ -291,6 +291,9 @@ public class RepoViewCommonViewer extends CommonViewer implements INavigatorCont
     }
 
     private void refreshNodeFromProperty(org.talend.core.model.properties.Property property) {
+        if (this.getTree() == null || this.getTree().isDisposed()) {
+            return;
+        }
         List<IRepositoryNode> nodes = new ArrayList<>();
         for (Object object : getExpandedElements()) {
             if (object instanceof IRepositoryNode) {


### PR DESCRIPTION
TUP-15968 Fix Get in a freshly install 6.1.2 Studio, this error in the log " org.eclipse.swt.SWTException: Failed to execute runnable (org.eclipse.swt.SWTException: Widget is disposed)
https://jira.talendforge.org/browse/TUP-15968