### PR TITLE
fix(TDI-33559): tAccessXX don't work when access database encrypted

### DIFF
--- a/main/plugins/org.talend.libraries.jdbc.access/pom.xml
+++ b/main/plugins/org.talend.libraries.jdbc.access/pom.xml
@@ -9,4 +9,54 @@
   </parent>
   <artifactId>org.talend.libraries.jdbc.access</artifactId>
   <packaging>eclipse-plugin</packaging>
+  
+  <properties>
+    <libs.dir>${project.basedir}/lib</libs.dir>
+  </properties>
+  
+  <build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <configuration>
+                <filesets>
+                	<fileset>
+                        <directory>${libs.dir}</directory>
+                        <includes>
+                            <include>talend-ucanaccess-utils-*.jar</include>
+                        </includes>
+                    </fileset>
+                </filesets>
+            </configuration>
+        </plugin>
+        <plugin>
+	        <groupId>org.apache.maven.plugins</groupId>
+	        <artifactId>maven-dependency-plugin</artifactId>
+	        <version>2.8</version>
+            <executions>
+            	<execution>
+                    <id>copy-jars</id>
+                    <phase>generate-sources</phase>
+                    <goals>
+                        <goal>copy</goal>
+                    </goals>
+                    <configuration>
+                        <artifactItems>
+                        	<artifactItem>
+                                <groupId>org.talend.libraries</groupId>
+                                <artifactId>talend-ucanaccess-utils</artifactId>
+                                <version>1.0.0</version>
+                                <type>jar</type>
+                                <overWrite>true</overWrite>
+                                <outputDirectory>${libs.dir}</outputDirectory>
+                            </artifactItem>
+                        </artifactItems>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+  	</plugins>
+  </build>
+  
 </project>


### PR DESCRIPTION
need to merge it after talend-ucanaccess-utils lib appear in talend-newbuild repository.