### PR TITLE
TESB-18908:Memory-Leak in TalendDataSource implementation

### DIFF
--- a/main/plugins/org.talend.librariesmanager/resources/java/routines/system/TalendDataSource.java
+++ b/main/plugins/org.talend.librariesmanager/resources/java/routines/system/TalendDataSource.java
@@ -38,4 +38,19 @@ public class TalendDataSource {
     public javax.sql.DataSource getRawDataSource() {
         return ds;
     }
+    
+    /**
+     * @Deprecated
+     * 
+     * This method will be removed in future release
+     * 
+     * close all the connections which is created by the data source inside
+     * 
+     * @throws SQLException
+     */
+    
+    public void close() throws SQLException {
+    	
+    }
+    
 }


### PR DESCRIPTION
There are still some components are using the close method, so we could remove the close method later.