### PR TITLE
bugfix TUP-17371

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/runtime/hd/IHDistributionVersion.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/runtime/hd/IHDistributionVersion.java
@@ -30,4 +30,6 @@ public interface IHDistributionVersion {
     String getDefaultConfig(String... keys);
 
     List<ModuleNeeded> getModulesNeeded();
+
+    boolean doSupportOozie();
 }


### PR DESCRIPTION
Context menu "Create Oozie" should not show on Cloudera Spark 2 Hadoop
Cluster

https://jira.talendforge.org/browse/TUP-17371