### PR TITLE
Typo fix

### DIFF
--- a/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/utils/DownloadModuleRunnable.java
+++ b/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/utils/DownloadModuleRunnable.java
@@ -65,7 +65,7 @@ abstract public class DownloadModuleRunnable implements IRunnableWithProgress {
         if (checkAndAcceptLicenses(subMonitor)) {
             downLoad(subMonitor);
         }
-        System.out.println("**Downlaod finished");
+        System.out.println("**Download finished");
         if (monitor != null) {
             monitor.setCanceled(subMonitor.isCanceled());
             monitor.done();

--- a/main/plugins/org.talend.registration/content/talendForgeDiage.html
+++ b/main/plugins/org.talend.registration/content/talendForgeDiage.html
@@ -423,7 +423,7 @@
     <tr>
       <td>
                   <ul>
-                        <li style="font-size:12px;font-family:Arial"><internationalization id="TalendForgeDialog.labelMessageOnePart1" /><b><internationalization id="TalendForgeDialog.labelMessageOnePart2" /></b><internationalization id="TalendForgeDialog.labelMessageOnePart3" /></li>
+                        <li style="font-size:12px;font-family:Arial"><internationalization id="TalendForgeDialog.labelMessageOnePart1" /> <b><internationalization id="TalendForgeDialog.labelMessageOnePart2" /></b> <internationalization id="TalendForgeDialog.labelMessageOnePart3" /></li>
                         <br/><br/>
                         <li style="font-size:12px;font-family:Arial"><internationalization id="TalendForgeDialog.labelMessageTwo1" /> <b><internationalization id="TalendForgeDialog.labelMessageTwo2" /></b> <internationalization id="TalendForgeDialog.labelMessageTwo3" /></li>
                         <br/><br/>


### PR DESCRIPTION
A trivial typo fix, but one that appears in the Studio console window. Also there is a lack of spaces around the second information message for downloading resources: "Downloadnew components and connectorsfrom Talend".