### PR TITLE
feat(TBD-5000): Add Spark 2.1 in local mode

### DIFF
--- a/main/plugins/org.talend.libraries.apache.cassandra/plugin.xml
+++ b/main/plugins/org.talend.libraries.apache.cassandra/plugin.xml
@@ -47,6 +47,12 @@
             mvn_uri="mvn:org.talend.libraries/spark-cassandra-connector-assembly-2.0.0-M3-patched-20161017/6.3.0"
             name="spark-cassandra-connector-assembly-2.0.0-M3-patched-20161017.jar">
       </libraryNeeded>
+      <libraryNeeded
+            context="plugin:org.talend.libraries.apache.cassandra"
+            id="spark-cassandra-connector-21"
+            mvn_uri="mvn:org.talend.libraries/spark-cassandra-connector-assembly-2.0.2-patched-20170519/6.3.0"
+            name="spark-cassandra-connector-assembly-2.0.2-patched-20170519.jar">
+      </libraryNeeded>
    </extension>
 
 </plugin>

--- a/main/plugins/org.talend.libraries.apache.cassandra/plugin.xml
+++ b/main/plugins/org.talend.libraries.apache.cassandra/plugin.xml
@@ -50,8 +50,8 @@
       <libraryNeeded
             context="plugin:org.talend.libraries.apache.cassandra"
             id="spark-cassandra-connector-21"
-            mvn_uri="mvn:org.talend.libraries/spark-cassandra-connector-assembly-2.0.2-patched-20170519/6.3.0"
-            name="spark-cassandra-connector-assembly-2.0.2-patched-20170519.jar">
+            mvn_uri="mvn:org.talend.libraries/spark-cassandra-connector-assembly-2.0.2/6.0.0"
+            name="spark-cassandra-connector-assembly-2.0.2.jar">
       </libraryNeeded>
    </extension>
 

--- a/main/plugins/org.talend.libraries.apache.cassandra/plugin.xml
+++ b/main/plugins/org.talend.libraries.apache.cassandra/plugin.xml
@@ -50,8 +50,8 @@
       <libraryNeeded
             context="plugin:org.talend.libraries.apache.cassandra"
             id="spark-cassandra-connector-21"
-            mvn_uri="mvn:org.talend.libraries/spark-cassandra-connector-assembly-2.0.2/6.0.0"
-            name="spark-cassandra-connector-assembly-2.0.2.jar">
+            mvn_uri="mvn:org.talend.libraries/spark-cassandra-connector-assembly-2.0.2-patched-20170519/6.0.0"
+            name="spark-cassandra-connector-assembly-2.0.2-patched-20170519.jar">
       </libraryNeeded>
    </extension>
 


### PR DESCRIPTION
We build the Spark Cassandra Connector against Scala 2.11 (spark-cassandra-connector-assembly-2.0.2-patched-20170519.jar is generated).
Please see https://github.com/Talend/spark-cassandra-connector/blob/master/doc/12_building_and_artifacts.md
