### PR TITLE
fix(TUP-18019)context group dialog popup manytimes when check service

### DIFF
--- a/main/plugins/org.talend.repository.metadata/src/main/java/org/talend/repository/ui/wizards/metadata/connection/database/DatabaseForm.java
+++ b/main/plugins/org.talend.repository.metadata/src/main/java/org/talend/repository/ui/wizards/metadata/connection/database/DatabaseForm.java
@@ -3858,7 +3858,13 @@ public class DatabaseForm extends AbstractForm {
         final ManagerConnection managerConnection = new ManagerConnection();
 
         if (isContextMode()) { // context mode
-            selectedContextType = ConnectionContextHelper.getContextTypeForContextMode(connectionItem.getConnection(), true);
+            String connectionTypeName = connectionItem.getConnection().getConnectionTypeName();
+            if (connectionTypeName.equals(EDatabaseConnTemplate.HBASE.getDBDisplayName())
+                    || connectionTypeName.equals(EDatabaseConnTemplate.HIVE.getDBDisplayName())) {
+                selectedContextType = ConnectionContextHelper.getContextTypeForContextMode(connectionItem.getConnection(), true);
+            } else {
+                selectedContextType = ConnectionContextHelper.getContextTypeForContextMode(connectionItem.getConnection());
+            }
             String urlStr = null;
             urlStr = DBConnectionContextUtils.setManagerConnectionValues(managerConnection, connectionItem, selectedContextType,
                     dbTypeCombo.getItem(dbTypeCombo.getSelectionIndex()), dbTypeCombo.getSelectionIndex());

--- a/main/plugins/org.talend.repository.metadata/src/main/java/org/talend/repository/ui/wizards/metadata/connection/database/DatabaseForm.java
+++ b/main/plugins/org.talend.repository.metadata/src/main/java/org/talend/repository/ui/wizards/metadata/connection/database/DatabaseForm.java
@@ -3858,7 +3858,7 @@ public class DatabaseForm extends AbstractForm {
         final ManagerConnection managerConnection = new ManagerConnection();
 
         if (isContextMode()) { // context mode
-            selectedContextType = ConnectionContextHelper.getContextTypeForContextMode(connectionItem.getConnection());
+            selectedContextType = ConnectionContextHelper.getContextTypeForContextMode(connectionItem.getConnection(), true);
             String urlStr = null;
             urlStr = DBConnectionContextUtils.setManagerConnectionValues(managerConnection, connectionItem, selectedContextType,
                     dbTypeCombo.getItem(dbTypeCombo.getSelectionIndex()), dbTypeCombo.getSelectionIndex());


### PR DESCRIPTION
*when have many context groups within Hive, Hbase, Hcate or HDFS, open
their wizard will not pop up select-context dialog now. 

*dialog will not appear when check service also.

https://jira.talendforge.org/browse/TUP-18019