### PR TITLE
fix(TDI-39518) tSendMail job with multiline Message cannot be moved from 6.1.1 to 6.4.1

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/utils/NodeUtil.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/utils/NodeUtil.java
@@ -950,10 +950,10 @@ public class NodeUtil {
         String result = "";
         int leftQuotes = original.indexOf("\"");
         int rightQuotes = original.indexOf("\"", leftQuotes + 1);
-        int fakeRightQuotes = original.indexOf("\\\"", leftQuotes + 1);
+        int fakeRightQuotes = getFakeRithtQuotes( original,leftQuotes);
         while (rightQuotes == fakeRightQuotes + 1) {
             rightQuotes = original.indexOf("\"", rightQuotes + 1);
-            fakeRightQuotes = original.indexOf("\\\"", fakeRightQuotes + 1);
+            fakeRightQuotes = getFakeRithtQuotes( original,fakeRightQuotes);
         }
         int leftPrev = 0;
         while (leftQuotes >= 0 && rightQuotes > leftQuotes) {
@@ -968,14 +968,42 @@ public class NodeUtil {
             leftQuotes = original.indexOf("\"", rightQuotes + 1);
             leftPrev = rightQuotes + 1;
             rightQuotes = original.indexOf("\"", leftQuotes + 1);
-            fakeRightQuotes = original.indexOf("\\\"", leftQuotes + 1);
+            fakeRightQuotes = getFakeRithtQuotes( original,leftQuotes);
             while (rightQuotes == fakeRightQuotes + 1) {
                 rightQuotes = original.indexOf("\"", rightQuotes + 1);
-                fakeRightQuotes = original.indexOf("\\\"", fakeRightQuotes + 1);
+                fakeRightQuotes = getFakeRithtQuotes( original,fakeRightQuotes);
             }
         }
         result += original.substring(leftPrev);
         return result;
+    }
+    
+    /**
+     * This method would avoid get wrong fakeRithQuotes index, like:
+     * "\"\\\\\"" the right quote is not fake one.
+     */
+    private static int getFakeRithtQuotes(String original, int fromIdex) {
+        int fakeRightQuotes = original.indexOf("\\\"", fromIdex + 1);
+        String quoteStr = "\\\"";
+        int count = 0;
+        while (fakeRightQuotes > 0) {
+            count++;
+            quoteStr = "\\" + quoteStr;
+            int tmpIndex = original.indexOf(quoteStr, fromIdex + 1);
+            if (tmpIndex > fakeRightQuotes || tmpIndex < 0) {
+                // If add even times "\\", then the index is -1 or bigger than we get fakeRightQuotes
+                // This means that this is really fake quote
+                if (count % 2 == 1) {
+                    break;
+                } else {// Else it is really a right quote, then need get and check next fakeRightQuotes
+                    fakeRightQuotes = original.indexOf("\\\"", fakeRightQuotes + 1);
+                    quoteStr = "\\\"";
+                    count = 0;
+                }
+            }
+
+        }
+        return fakeRightQuotes;
     }
 
     /**


### PR DESCRIPTION
For https://jira.talendforge.org/browse/TDI-39518

Fix issue:
Get wrong right quote index when replace CRLF for memo property value.