### PR TITLE
fix(TDI-39670) Side effect when using TalendDate.formatDateInUTC() and TalendDate.parseDate()

### DIFF
--- a/main/plugins/org.talend.librariesmanager/resources/java/routines/TalendDate.java
+++ b/main/plugins/org.talend.librariesmanager/resources/java/routines/TalendDate.java
@@ -143,8 +143,11 @@ public class TalendDate {
 
     public synchronized static String formatDateInUTC(String pattern, java.util.Date date) {
         DateFormat format = FastDateParser.getInstance(pattern);
+        TimeZone originalTZ = format.getTimeZone();
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return format.format(date);
+        String dateStr = format.format(date);
+        format.setTimeZone(originalTZ);
+        return dateStr;
     }
 
     /**
@@ -947,9 +950,11 @@ public class TalendDate {
                 }
             }
             DateFormat df = FastDateParser.getInstance(pattern);
+            TimeZone originalTZ = df.getTimeZone();
             df.setTimeZone(TimeZone.getTimeZone("UTC"));
             df.setLenient(isLenient);
             Date d = df.parse(stringDate);
+            df.setTimeZone(originalTZ);
             if (hasZone) {
                 int offset = df.getCalendar().get(Calendar.ZONE_OFFSET);
                 char sign = offset >= 0 ? '+' : '-';


### PR DESCRIPTION
For jira: https://jira.talendforge.org/browse/TDI-39670

Make sure `TalendDate.formatDateInUTC()` and `TalendDate.parseDateInUTC()` don't change the original timezone of `FastDateParser.getInstance(pattern)`
This would influence other format or parse method.