### PR TITLE
fix(TUP-19042) Find back project name if parent is null

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/repository/ProjectManager.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/repository/ProjectManager.java
@@ -313,7 +313,7 @@ public final class ProjectManager {
             }
             if (object instanceof Item) {
                 if (((Item) object).getParent() == null) { // may be a routelet from reference project
-                    org.talend.core.model.properties.Project refProject = getRouteletReferenceProject((Item)object);
+                    org.talend.core.model.properties.Project refProject = getProjectFromItemWithoutParent((Item)object);
                     if (refProject != null) {
                         return refProject;
                     }
@@ -332,12 +332,11 @@ public final class ProjectManager {
     }
 
     /*
-     * returns reference project where the given routelet comes from, or null
-     * in case if the routelet is from the current project
+     * Returns the project name found from the current path if the parent is null
      */
-    private org.talend.core.model.properties.Project getRouteletReferenceProject(Item item) {
+    private org.talend.core.model.properties.Project getProjectFromItemWithoutParent(Item item) {
 
-        final String URI_PREFIX = "platform:/resource/";
+        final String URI_PREFIX = "platform:/resource/"; //$NON-NLS-1$
 
         org.talend.core.model.properties.ItemState state = item.getState();
 
@@ -349,21 +348,19 @@ public final class ProjectManager {
                 }
                 String eProxyUriString = eProxyUri.toString();
                 if (eProxyUriString != null && eProxyUriString.startsWith(URI_PREFIX)) {
+                    
                     String tmpString = eProxyUriString.substring(URI_PREFIX.length());
-                    if (!tmpString.contains("/routelets/")) {
-                        return null;
-                    }
-                    String projectLabel = tmpString.substring(0, tmpString.indexOf("/"));
+                    String projectLabel = tmpString.substring(0, tmpString.indexOf("/")); //$NON-NLS-1$
 
                     if (currentProject == null) {
                         initCurrentProject();
                     }
 
-                    if (currentProject.getLabel().equalsIgnoreCase(projectLabel)) {
+                    if (currentProject.getTechnicalLabel().equalsIgnoreCase(projectLabel)) {
                         return currentProject.getEmfProject();
                     }
                     for (Project project : getAllReferencedProjects()) {
-                        if (project.getLabel().equalsIgnoreCase(projectLabel)) {
+                        if (project.getTechnicalLabel().equalsIgnoreCase(projectLabel)) {
                             return project.getEmfProject();
                         }
                     }


### PR DESCRIPTION
Re-used simply the code existing in the past used for ESB only. (working on their side)
But make it more standard to use it on every kind of item.