### PR TITLE
[TESB-20924] cConfig cannot install the external jar

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/ILibraryManagerService.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/ILibraryManagerService.java
@@ -54,6 +54,9 @@ public interface ILibraryManagerService extends IService {
 
     public void deploy(URI jarFileUri, String mavenUri, IProgressMonitor... monitorWrap);
 
+    public void deploy(URI jarFileUri, String mavenUri, boolean updateNexusJar, IProgressMonitor... monitorWrap);
+
+
     /**
      * 
      * DOC wchen Comment method "deploy".Deploy moduleName:platformUri index to LibrariesIndex.xml

--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/general/ILibrariesService.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/general/ILibrariesService.java
@@ -65,6 +65,8 @@ public interface ILibrariesService extends IService {
 
     public void deployLibrary(URL source, String mavenUri, boolean refresh) throws IOException;
 
+    public void deployLibrary(URL source, String mavenUri, boolean refresh, boolean updateNexusJar) throws IOException;
+
     public void deployLibrarys(URL[] source) throws IOException;
 
     public void undeployLibrary(String jarName) throws IOException;

--- a/main/plugins/org.talend.core.ui/src/main/java/org/talend/core/ui/metadata/celleditor/ModuleListCellEditor.java
+++ b/main/plugins/org.talend.core.ui/src/main/java/org/talend/core/ui/metadata/celleditor/ModuleListCellEditor.java
@@ -205,7 +205,7 @@ public class ModuleListCellEditor extends DialogCellEditor {
         }
         // enable to refresh component setting after change modules.
         IElement element = this.tableParam.getElement();
-        if (element != null) {
+        if (element != null && !"cConfig".equals(element.getElementParameter("COMPONENT_NAME").getValue())) {
             IElementParameter updateComponentsParam = element.getElementParameter("UPDATE_COMPONENTS"); //$NON-NLS-1$
             if (updateComponentsParam != null) {
                 updateComponentsParam.setValue(Boolean.TRUE);

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/AbstractLibrariesService.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/AbstractLibrariesService.java
@@ -136,7 +136,7 @@ public abstract class AbstractLibrariesService implements ILibrariesService {
         }
         final File sourceFile = new File(decode);
 
-        localLibraryManager.deploy(sourceFile.toURI(), mavenUri, updateNexusJar, null);
+        localLibraryManager.deploy(sourceFile.toURI(), mavenUri, updateNexusJar);
 
         refreshLocal(new String[] { sourceFile.getName() });
         if (refresh) {

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/AbstractLibrariesService.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/AbstractLibrariesService.java
@@ -124,6 +124,10 @@ public abstract class AbstractLibrariesService implements ILibrariesService {
 
     @Override
     public void deployLibrary(URL source, String mavenUri, boolean refresh) throws IOException {
+        deployLibrary(source, mavenUri, refresh, true);
+    }
+
+    public void deployLibrary(URL source, String mavenUri, boolean refresh, boolean updateNexusJar) throws IOException {
         String decode = null;
         if (source.getFile().contains("%20")) {
             decode = URLDecoder.decode(source.getFile(), "UTF-8");
@@ -132,13 +136,12 @@ public abstract class AbstractLibrariesService implements ILibrariesService {
         }
         final File sourceFile = new File(decode);
 
-        localLibraryManager.deploy(sourceFile.toURI(), mavenUri);
+        localLibraryManager.deploy(sourceFile.toURI(), mavenUri, updateNexusJar, null);
 
         refreshLocal(new String[] { sourceFile.getName() });
         if (refresh) {
             checkLibraries();
         }
-
     }
 
     @Override

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/LibrariesService.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/LibrariesService.java
@@ -263,6 +263,7 @@ public class LibrariesService implements ILibrariesService {
         getLibrariesService().deployLibrary(source, mavenUri, refresh);
     }
 
+    @Override
     public void deployLibrary(URL source, String mavenUri, boolean refresh, boolean updateNexusJar) throws IOException {
         getLibrariesService().deployLibrary(source, mavenUri, refresh, updateNexusJar);
     }

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/LibrariesService.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/LibrariesService.java
@@ -263,4 +263,8 @@ public class LibrariesService implements ILibrariesService {
         getLibrariesService().deployLibrary(source, mavenUri, refresh);
     }
 
+    public void deployLibrary(URL source, String mavenUri, boolean refresh, boolean updateNexusJar) throws IOException {
+        getLibrariesService().deployLibrary(source, mavenUri, refresh, updateNexusJar);
+    }
+
 }

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/LocalLibraryManager.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/LocalLibraryManager.java
@@ -145,6 +145,11 @@ public class LocalLibraryManager implements ILibraryManagerService, IChangedLibr
 
     @Override
     public void deploy(URI jarFileUri, String mavenUri, IProgressMonitor... monitorWrap) {
+      deploy(jarFileUri, mavenUri, true, monitorWrap);
+    }
+
+    @Override
+    public void deploy(URI jarFileUri, String mavenUri, boolean updateNexusJar, IProgressMonitor... monitorWrap) {
         if (jarFileUri.isOpaque()) {
             return;
         }
@@ -152,7 +157,7 @@ public class LocalLibraryManager implements ILibraryManagerService, IChangedLibr
         if (file == null || !file.exists()) {
             return;
         }
-        install(file, mavenUri, true, monitorWrap);
+        install(file, mavenUri, updateNexusJar, monitorWrap);
         // deploy to configuration/lib/java if tac still use the svn lib
         try {
             if (isSvnLibSetup()) {


### PR DESCRIPTION
In scope of the commit:

- Prevent appearance of orange "Additional library required" bar with "Install..." button for cConfig component when exteran ljar is added to dependency list (ModuleListCellEditor.java)

- Added method to LibraryService API to publish jars only to local studio reposiotry, without attempting to reach Nexus