### PR TITLE
fix(TUP-19590) Fix the problem of download of jar during build

### DIFF
--- a/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/ui/dialogs/ExternalModulesInstallDialog.java
+++ b/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/ui/dialogs/ExternalModulesInstallDialog.java
@@ -998,6 +998,9 @@ public class ExternalModulesInstallDialog extends TitleAreaDialog implements IMo
                                 }
                             }
                         }
+                        ILibrariesService librariesService = (ILibrariesService) GlobalServiceRegister.getDefault().getService(
+                                ILibrariesService.class);
+                        librariesService.checkLibraries();
                     }
                 });
             }

--- a/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/ui/dialogs/ExternalModulesInstallDialogWithProgress.java
+++ b/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/ui/dialogs/ExternalModulesInstallDialogWithProgress.java
@@ -47,6 +47,7 @@ import org.talend.commons.exception.ExceptionHandler;
 import org.talend.commons.utils.system.EclipseCommandLine;
 import org.talend.core.model.general.ModuleNeeded;
 import org.talend.core.model.general.ModuleToInstall;
+import org.talend.librariesmanager.ui.LibManagerUiPlugin;
 import org.talend.librariesmanager.utils.DownloadModuleRunnableWithLicenseDialog;
 import org.talend.librariesmanager.utils.RemoteModulesHelper;
 
@@ -313,6 +314,7 @@ public class ExternalModulesInstallDialogWithProgress extends ExternalModulesIns
                 stopped(state);
             }
             activeRunningOperations--;
+            LibManagerUiPlugin.getDefault().getLibrariesService().checkLibraries();
         }
     }
 

--- a/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/utils/DownloadModuleRunnable.java
+++ b/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/utils/DownloadModuleRunnable.java
@@ -48,6 +48,8 @@ abstract public class DownloadModuleRunnable implements IRunnableWithProgress {
 
     protected Set<String> installedModules;
 
+    private boolean checkLibraries;
+
     /**
      * DOC sgandon DownloadModuleRunnable constructor comment.
      * 
@@ -58,6 +60,12 @@ abstract public class DownloadModuleRunnable implements IRunnableWithProgress {
         this.toDownload = toDownload;
         downloadFailed = new HashSet<String>();
         installedModules = new HashSet<String>();
+        checkLibraries = true;
+    }
+
+    public DownloadModuleRunnable(List<ModuleToInstall> toDownload, boolean checkLibraries) {
+        this(toDownload);
+        this.checkLibraries = checkLibraries;
     }
 
     @Override
@@ -89,8 +97,8 @@ abstract public class DownloadModuleRunnable implements IRunnableWithProgress {
                 try {
                     // check license
                     boolean isLicenseAccepted = module.isFromCustomNexus()
-                            || (LibManagerUiPlugin.getDefault().getPreferenceStore().contains(module.getLicenseType()) && LibManagerUiPlugin
-                                    .getDefault().getPreferenceStore().getBoolean(module.getLicenseType()));
+                            || (LibManagerUiPlugin.getDefault().getPreferenceStore().contains(module.getLicenseType())
+                                    && LibManagerUiPlugin.getDefault().getPreferenceStore().getBoolean(module.getLicenseType()));
 
                     boolean hasRepositoryUrl = false;
                     String moduleMvnUri = module.getMavenUri();
@@ -133,11 +141,12 @@ abstract public class DownloadModuleRunnable implements IRunnableWithProgress {
             } else {
                 downloadFailed.add(module.getName());
             }
-            ILibrariesService librariesService = (ILibrariesService) GlobalServiceRegister.getDefault().getService(
-                    ILibrariesService.class);
+        }
+        if (checkLibraries) {
+            ILibrariesService librariesService = (ILibrariesService) GlobalServiceRegister.getDefault()
+                    .getService(ILibrariesService.class);
             librariesService.checkLibraries();
         }
-
     }
 
     protected boolean hasLicensesToAccept() {
@@ -169,8 +178,8 @@ abstract public class DownloadModuleRunnable implements IRunnableWithProgress {
                 @Override
                 public void run() {
                     AcceptModuleLicensesWizard licensesWizard = new AcceptModuleLicensesWizard(toDownload);
-                    AcceptModuleLicensesWizardDialog wizardDialog = new AcceptModuleLicensesWizardDialog(PlatformUI
-                            .getWorkbench().getActiveWorkbenchWindow().getShell(), licensesWizard, toDownload, monitor);
+                    AcceptModuleLicensesWizardDialog wizardDialog = new AcceptModuleLicensesWizardDialog(
+                            PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), licensesWizard, toDownload, monitor);
                     wizardDialog.setPageSize(700, 380);
                     wizardDialog.create();
                     if (wizardDialog.open() != Window.OK) {

--- a/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/utils/DownloadModuleRunnableWithLicenseDialog.java
+++ b/main/plugins/org.talend.librariesmanager.ui/src/main/java/org/talend/librariesmanager/utils/DownloadModuleRunnableWithLicenseDialog.java
@@ -33,7 +33,7 @@ public class DownloadModuleRunnableWithLicenseDialog extends DownloadModuleRunna
      * DOC sgandon DownloadModuleRunnableWithLicenseDialog constructor comment.
      */
     public DownloadModuleRunnableWithLicenseDialog(List<ModuleToInstall> toDownload, Shell shell) {
-        super(toDownload);
+        super(toDownload, false);
         this.shell = shell;
 
     }


### PR DESCRIPTION
Change done:
- have only one check of libraries instead of multiple for every jar installed (not related to current issue, but will improve performances also)
- when use the download dialog to install, do the check of libraries only after install the full list of jars from the dialog itself (instead of the download class)