### PR TITLE
TESB-21435 Default Route dependencies are added

### DIFF
--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -703,18 +703,18 @@ public class ModulesNeededProvider {
     }
     
     public static ModuleNeeded getComponentModuleById(String palettType, String moduleId) {
-    	if (service != null) {
-        	for(IComponent c : service.getComponentsFactory().getComponents()) {
-        		for(ModuleNeeded m: c.getModulesNeeded()) {
-        			String pt = c.getPaletteType();
-        			if((palettType == null || palettType.equalsIgnoreCase(pt)) 
-        					&& m.getId() != null && m.getId().equalsIgnoreCase(moduleId)) {
-        				return m;
-        			}
-        		}
-        	}
+        if (service != null) {
+            for(IComponent c : service.getComponentsFactory().getComponents()) {
+                for(ModuleNeeded m: c.getModulesNeeded()) {
+                    String pt = c.getPaletteType();
+                    if((palettType == null || palettType.equalsIgnoreCase(pt)) 
+                       && m.getId() != null && m.getId().equalsIgnoreCase(moduleId)) {
+                       return m;
+                    }
+                }
+            }
         }
-    	return null;
+        return null;
     }
     
     public static List<ModuleNeeded> getModulesNeededForRoutes() {

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -122,10 +122,6 @@ public class ModulesNeededProvider {
     private static final String TALEND_FILE_NAME = "cache";
 
     private static final List<IChangedLibrariesListener> listeners = new ArrayList<IChangedLibrariesListener>();
-    
-    private static final String CAMEL_VERSION = "2.20.1";
-    
-    private static final String SPRING_VERSION = "4.3.10.RELEASE";
 
     private static IRepositoryService service = null;
     static {
@@ -485,18 +481,8 @@ public class ModulesNeededProvider {
             // route do not save any relateionship with beans , so add all for now
             Set<ModuleNeeded> modulesNeededForBean = ModulesNeededProvider.getCodesModuleNeededs(
                     ERepositoryObjectType.getType("BEANS"), false);
-            // minimal set of dependencies which are required by "empty" ROUTE / ROUTELET
-            modulesNeeded.add(new ModuleNeeded(null, "camel-core-" + CAMEL_VERSION + ".jar", 
-            		null, false));
-            modulesNeeded.add(new ModuleNeeded(null, "camel-spring-" + CAMEL_VERSION + ".jar",
-            		null, false));
-            modulesNeeded.add(new ModuleNeeded(null, "spring-context-" + SPRING_VERSION + ".jar",
-            		null, false));
-            modulesNeeded.add(new ModuleNeeded(null, "spring-beans-" + SPRING_VERSION + ".jar",
-            		null, false));
-            modulesNeeded.add(new ModuleNeeded(null, "spring-core-" + SPRING_VERSION + ".jar", 
-            		null, false));
             modulesNeeded.addAll(modulesNeededForBean);
+            modulesNeeded.addAll(getModulesNeededForRoutes());
         }
         return modulesNeeded;
     }
@@ -715,6 +701,31 @@ public class ModulesNeededProvider {
         }
         return importNeedsList;
     }
+    
+    public static ModuleNeeded getComponentModuleById(String palettType, String moduleId) {
+    	if (service != null) {
+        	for(IComponent c : service.getComponentsFactory().getComponents()) {
+        		for(ModuleNeeded m: c.getModulesNeeded()) {
+        			String pt = c.getPaletteType();
+        			if((palettType == null || palettType.equalsIgnoreCase(pt)) 
+        					&& m.getId() != null && m.getId().equalsIgnoreCase(moduleId)) {
+        				return m;
+        			}
+        		}
+        	}
+        }
+    	return null;
+    }
+    
+    public static List<ModuleNeeded> getModulesNeededForRoutes() {
+        List<ModuleNeeded> importNeedsList = new ArrayList<ModuleNeeded>();
+        importNeedsList.add(getComponentModuleById("CAMEL", "camel-core"));
+        importNeedsList.add(getComponentModuleById("CAMEL", "camel-spring"));
+        importNeedsList.add(getComponentModuleById("CAMEL", "spring-context"));
+        importNeedsList.add(getComponentModuleById("CAMEL", "spring-beans"));
+        importNeedsList.add(getComponentModuleById("CAMEL", "spring-core"));
+        return importNeedsList;
+    }    
 
     private static void getRefRoutines(List<IRepositoryViewObject> routines,
              Project mainProject, ERepositoryObjectType type) {

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -122,6 +122,10 @@ public class ModulesNeededProvider {
     private static final String TALEND_FILE_NAME = "cache";
 
     private static final List<IChangedLibrariesListener> listeners = new ArrayList<IChangedLibrariesListener>();
+    
+    private static final String CAMEL_VERSION = "2.20.1";
+    
+    private static final String SPRING_VERSION = "4.3.10.RELEASE";
 
     private static IRepositoryService service = null;
     static {
@@ -481,6 +485,17 @@ public class ModulesNeededProvider {
             // route do not save any relateionship with beans , so add all for now
             Set<ModuleNeeded> modulesNeededForBean = ModulesNeededProvider.getCodesModuleNeededs(
                     ERepositoryObjectType.getType("BEANS"), false);
+            // minimal set of dependencies which are required by "empty" ROUTE / ROUTELET
+            modulesNeeded.add(new ModuleNeeded(null, "camel-core-" + CAMEL_VERSION + ".jar", 
+            		null, false));
+            modulesNeeded.add(new ModuleNeeded(null, "camel-spring-" + CAMEL_VERSION + ".jar",
+            		null, false));
+            modulesNeeded.add(new ModuleNeeded(null, "spring-context-" + SPRING_VERSION + ".jar",
+            		null, false));
+            modulesNeeded.add(new ModuleNeeded(null, "spring-beans-" + SPRING_VERSION + ".jar",
+            		null, false));
+            modulesNeeded.add(new ModuleNeeded(null, "spring-core-" + SPRING_VERSION + ".jar", 
+            		null, false));
             modulesNeeded.addAll(modulesNeededForBean);
         }
         return modulesNeeded;


### PR DESCRIPTION
Current issue is based on very "old" problem which is reproducable from Studio 6.4.1 (I did not check with oldest versions).

The problem is - empty Routes  are not compilable (for example, we will see many errors if  we open Route using "code" tab from Studio).
The reason of issue is - we have no "default" Route dependencies (all  dependencies are "extracted" from Route components). List of required "default" dependencies:

camel-core-VERSION.jar
camel-spring-VERSION.jar
spring-context-VERSION.jar
spring-beans-VERSION.jar
spring-core-VERSION.jar

We did not see "pup up with 'Job compile error'" before because of coresponding errors was supressed explicitly.

So, we can resolve this issue in few ways:

1. suppress error again, but we will face the same problem in case of Project will be built out of Studio (for example, using external Maven etc).
2. create list of default dependencies which must be added to any Route

Curent PR implements approach №2