### PR TITLE
fix(TESB-21651): No-op backupPomFile in PomUtil if project is null.

### DIFF
--- a/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/PomUtil.java
+++ b/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/PomUtil.java
@@ -853,6 +853,9 @@ public class PomUtil {
     }
 
     public static void backupPomFile(ITalendProcessJavaProject talendProject) {
+        if (talendProject == null) {
+            return;
+        }
         final IProject project = talendProject.getProject();
         final IFile backFile = project.getFile(TalendMavenConstants.POM_BACKUP_FILE_NAME);
         final IFile pomFile = project.getFile(TalendMavenConstants.POM_FILE_NAME);


### PR DESCRIPTION
Assuming that PomUtil.backupPomFile(...) can be invoked in cases where no project is present, it will no longer throw an NPE but no-op and return.