### PR TITLE
fix(TUP-19883): Avoid NPE when closing reference project settings.

### DIFF
--- a/main/plugins/org.talend.designer.maven.ui/src/main/java/org/talend/designer/maven/ui/setting/project/page/MavenProjectSettingPage.java
+++ b/main/plugins/org.talend.designer.maven.ui/src/main/java/org/talend/designer/maven/ui/setting/project/page/MavenProjectSettingPage.java
@@ -114,7 +114,9 @@ public class MavenProjectSettingPage extends AbstractProjectSettingPage {
 	@Override
 	public boolean performOk() {
 		boolean ok = super.performOk();
-		preferenceStore.setValue(MavenConstants.POM_FILTER, filter);
+		if (preferenceStore != null) {
+			preferenceStore.setValue(MavenConstants.POM_FILTER, filter);
+		}
 		return ok;
 	}
 


### PR DESCRIPTION
This fix avoids an NPE which occurs when the reference project dialog is closed with "ok" and avoids that the reference project is really added.