### PR TITLE
fix(TESB-22034): Fix handling of non-required bean libs in route builds.

### DIFF
--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -703,15 +703,16 @@ public class ModulesNeededProvider {
             EList imports = routine.getImports();
             for (Object o : imports) {
                 IMPORTType currentImport = (IMPORTType) o;
-                if (currentImport.isREQUIRED()) {
-
-                    // FIXME SML i18n
-                    ModuleNeeded toAdd = new ModuleNeeded(context, currentImport.getMODULE(), currentImport.getMESSAGE(),
-                            currentImport.isREQUIRED());
-                    toAdd.setMavenUri(currentImport.getMVN());
-                    // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);
-                    importNeedsList.add(toAdd);
+                boolean isRequired = currentImport.isREQUIRED();
+                // FIXME SML i18n
+                ModuleNeeded toAdd = new ModuleNeeded(context, currentImport.getMODULE(), currentImport.getMESSAGE(),
+                        isRequired);
+                toAdd.setMavenUri(currentImport.getMVN());
+                if (!isRequired) {
+                	toAdd.setBundleName("osgi-exclude");
                 }
+                // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);
+                importNeedsList.add(toAdd);
             }
         }
         return importNeedsList;

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -708,7 +708,7 @@ public class ModulesNeededProvider {
                 ModuleNeeded toAdd = new ModuleNeeded(context, currentImport.getMODULE(), currentImport.getMESSAGE(),
                         isRequired);
                 toAdd.setMavenUri(currentImport.getMVN());
-                if (!isRequired) {
+                if (!isRequired && "BeanItem".equals(routine.eClass().getName())) {
                 	toAdd.setBundleName("osgi-exclude");
                 }
                 // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);


### PR DESCRIPTION
The expected handling of non-required libraries declared as bean dependencies is the following:

1. At compile time, the non-required library needs to be present.
2. At OSGi bundle build, the non-required library must not be included in the bundle, but the packages used by classes in the bundle shall be added to the imports in the manifest.
3. At microservice build, the non-required library shall be physically added.

The present fix changes the handling of non-required libraries to meet these expectations.