### PR TITLE
TESB-22034: Fix handling of non-required bean libs in route builds

### DIFF
--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -125,6 +125,11 @@ public class ModulesNeededProvider {
     private static final List<IChangedLibrariesListener> listeners = new ArrayList<IChangedLibrariesListener>();
 
     private static IRepositoryService service = null;
+
+    private static List<ModuleNeeded> importNeedsListForRoutes;
+
+    private static List<ModuleNeeded> importNeedsListForBeans;
+
     static {
         if (GlobalServiceRegister.getDefault().isServiceRegistered(IRepositoryService.class)) {
             service = (IRepositoryService) GlobalServiceRegister.getDefault().getService(IRepositoryService.class);
@@ -698,10 +703,14 @@ public class ModulesNeededProvider {
             EList imports = routine.getImports();
             for (Object o : imports) {
                 IMPORTType currentImport = (IMPORTType) o;
+                boolean isRequired = currentImport.isREQUIRED();
                 // FIXME SML i18n
                 ModuleNeeded toAdd = new ModuleNeeded(context, currentImport.getMODULE(), currentImport.getMESSAGE(),
-                        currentImport.isREQUIRED());
+                        isRequired);
                 toAdd.setMavenUri(currentImport.getMVN());
+                if (!isRequired && "BeanItem".equals(routine.eClass().getName())) {
+                    toAdd.setBundleName("osgi-exclude");
+                }
                 // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);
                 importNeedsList.add(toAdd);
             }
@@ -746,22 +755,29 @@ public class ModulesNeededProvider {
     }
 
     public static List<ModuleNeeded> getModulesNeededForRoutes() {
-        List<ModuleNeeded> importNeedsList = new ArrayList<ModuleNeeded>();
-        importNeedsList.add(getComponentModuleById("CAMEL", "camel-core"));
-        importNeedsList.add(getComponentModuleById("CAMEL", "camel-spring"));
-        importNeedsList.add(getComponentModuleById("CAMEL", "spring-context"));
-        importNeedsList.add(getComponentModuleById("CAMEL", "spring-beans"));
-        importNeedsList.add(getComponentModuleById("CAMEL", "spring-core"));
-        return importNeedsList;
+        if (importNeedsListForRoutes == null) {
+            importNeedsListForRoutes = new ArrayList<ModuleNeeded>();
+            importNeedsListForRoutes.add(getComponentModuleById("CAMEL", "camel-core"));
+            importNeedsListForRoutes.add(getComponentModuleById("CAMEL", "camel-spring"));
+            importNeedsListForRoutes.add(getComponentModuleById("CAMEL", "spring-context"));
+            importNeedsListForRoutes.add(getComponentModuleById("CAMEL", "spring-beans"));
+            importNeedsListForRoutes.add(getComponentModuleById("CAMEL", "spring-core"));
+        }
+        return importNeedsListForRoutes;
     }
 
     public static List<ModuleNeeded> getModulesNeededForBeans() {
-        List<ModuleNeeded> importNeedsList = getModulesNeededForRoutes();
-        
-        importNeedsList.add(getComponentModuleById("CAMEL", "camel-cxf"));
-        importNeedsList.add(getComponentModuleById("CAMEL", "cxf-core"));
-        importNeedsList.add(getComponentModuleById("CAMEL", "javax.ws.rs-api"));
-        return importNeedsList;
+        if (importNeedsListForBeans == null) {
+
+            importNeedsListForBeans = getModulesNeededForRoutes();
+            importNeedsListForBeans.add(getComponentModuleById("CAMEL", "camel-cxf"));
+            importNeedsListForBeans.add(getComponentModuleById("CAMEL", "cxf-core"));
+            importNeedsListForBeans.add(getComponentModuleById("CAMEL", "javax.ws.rs-api"));
+            for (ModuleNeeded need : importNeedsListForBeans) {
+                need.setRequired(false);
+            }
+        }
+        return importNeedsListForBeans;
     }
 
     private static void getRefRoutines(List<IRepositoryViewObject> routines, Project mainProject, ERepositoryObjectType type) {


### PR DESCRIPTION
TESB-22034: Fix handling of non-required bean libs in route builds