### PR TITLE
fix(TESB-22034): Improved handling of non-required bean deps in routes.

### DIFF
--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -709,7 +709,7 @@ public class ModulesNeededProvider {
                         isRequired);
                 toAdd.setMavenUri(currentImport.getMVN());
                 if (!isRequired && "BeanItem".equals(routine.eClass().getName())) {
-                	toAdd.setBundleName("osgi-exclude");
+                	toAdd.getExtraAttributes().put("IS_OSGI_EXCLUDED", Boolean.TRUE);
                 }
                 // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);
                 importNeedsList.add(toAdd);

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -703,15 +703,16 @@ public class ModulesNeededProvider {
             EList imports = routine.getImports();
             for (Object o : imports) {
                 IMPORTType currentImport = (IMPORTType) o;
-                if (currentImport.isREQUIRED()) {
-
-                    // FIXME SML i18n
-                    ModuleNeeded toAdd = new ModuleNeeded(context, currentImport.getMODULE(), currentImport.getMESSAGE(),
-                            currentImport.isREQUIRED());
-                    toAdd.setMavenUri(currentImport.getMVN());
-                    // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);
-                    importNeedsList.add(toAdd);
+                boolean isRequired = currentImport.isREQUIRED();
+                // FIXME SML i18n
+                ModuleNeeded toAdd = new ModuleNeeded(context, currentImport.getMODULE(), currentImport.getMESSAGE(),
+                        isRequired);
+                toAdd.setMavenUri(currentImport.getMVN());
+                if (!isRequired) {
+                	toAdd.setBundleName("osgi-exclude");
                 }
+                // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);
+                importNeedsList.add(toAdd);
             }
         }
         return importNeedsList;

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -708,7 +708,7 @@ public class ModulesNeededProvider {
                 ModuleNeeded toAdd = new ModuleNeeded(context, currentImport.getMODULE(), currentImport.getMESSAGE(),
                         isRequired);
                 toAdd.setMavenUri(currentImport.getMVN());
-                if (!isRequired) {
+                if (!isRequired && "BeanItem".equals(routine.eClass().getName())) {
                 	toAdd.setBundleName("osgi-exclude");
                 }
                 // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);


### PR DESCRIPTION
The handling of non-required dependencies of beans used by routes has been improved to use a separate attribute and no longer bear any risk of interfering with dependency processing for routines.