### PR TITLE
fix(TESB-22034): Improved handling of non-required bean deps in routes.

### DIFF
--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/ModulesNeededProvider.java
@@ -709,7 +709,7 @@ public class ModulesNeededProvider {
                         isRequired);
                 toAdd.setMavenUri(currentImport.getMVN());
                 if (!isRequired && "BeanItem".equals(routine.eClass().getName())) {
-                    toAdd.setBundleName("osgi-exclude");
+                	toAdd.getExtraAttributes().put("IS_OSGI_EXCLUDED", Boolean.TRUE);
                 }
                 // toAdd.setStatus(ELibraryInstallStatus.INSTALLED);
                 importNeedsList.add(toAdd);


### PR DESCRIPTION
The handling of non-required dependencies of beans used by routes has been improved to use a separate attribute and no longer bear any risk of interfering with dependency processing for routines.