### PR TITLE
fix(TESB-22183): Add support for circular WSDL imports to WSDLLoader.

### DIFF
--- a/main/plugins/org.talend.utils/src/main/java/org/talend/utils/wsdl/WSDLLoader.java
+++ b/main/plugins/org.talend.utils/src/main/java/org/talend/utils/wsdl/WSDLLoader.java
@@ -99,7 +99,7 @@ public class WSDLLoader {
 			processedWSDLLocations.add(wsdlLocation);
 			for(int index = 0; index < imports.getLength(); ++index) {
 				Element wsdlImport = (Element)imports.item(index);
-				String location = wsdlImport.getAttribute("locations");
+				String location = wsdlImport.getAttribute("location");
 				if (processedWSDLLocations.contains(location)) {
 					continue;
 				}

--- a/main/plugins/org.talend.utils/src/main/java/org/talend/utils/wsdl/WSDLLoader.java
+++ b/main/plugins/org.talend.utils/src/main/java/org/talend/utils/wsdl/WSDLLoader.java
@@ -23,6 +23,8 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -64,12 +66,16 @@ public class WSDLLoader {
 
 	private final Map<String, Collection<URL>> importedSchemas = new HashMap<String, Collection<URL>>();
 
-	public Map<String, InputStream> load(String wsdlLocation, String filenameTemplate) throws InvocationTargetException {
-		filenameIndex = 0;
-		return load(null, wsdlLocation, filenameTemplate);
+	public WSDLLoader() {
+		super();
 	}
 
-	private Map<String, InputStream> load(URL baseURL, String wsdlLocation, String filenameTemplate) throws InvocationTargetException {
+	public Map<String, InputStream> load(String wsdlLocation, String filenameTemplate) throws InvocationTargetException {
+		filenameIndex = 0;
+		return load(null, wsdlLocation, filenameTemplate, new LinkedList<String>());
+	}
+
+	private Map<String, InputStream> load(URL baseURL, String wsdlLocation, String filenameTemplate, List<String> processedWSDLLocations) throws InvocationTargetException {
 		Map<String, InputStream> wsdls = new HashMap<String, InputStream>();
 		try {
 			final URL wsdlURL = getURL(baseURL, wsdlLocation);
@@ -90,10 +96,15 @@ public class WSDLLoader {
 			// wsdl:import
 			final NodeList imports = wsdlDocument.getElementsByTagNameNS(
 					WSDL_NS, "import");
+			processedWSDLLocations.add(wsdlLocation);
 			for(int index = 0; index < imports.getLength(); ++index) {
 				Element wsdlImport = (Element)imports.item(index);
+				String location = wsdlImport.getAttribute("locations");
+				if (processedWSDLLocations.contains(location)) {
+					continue;
+				}
 				String filename = String.format(filenameTemplate, filenameIndex++);
-				Map<String, InputStream> importedWsdls = new WSDLLoader().load(wsdlURL, wsdlImport.getAttribute("location"), filenameTemplate);
+				Map<String, InputStream> importedWsdls = new WSDLLoader().load(wsdlURL, location, filenameTemplate, processedWSDLLocations);
 				wsdlImport.setAttribute("location", filename);
 				wsdls.put(filename, importedWsdls.remove(DEFAULT_FILENAME));
 				wsdls.putAll(importedWsdls);

--- a/test/plugins/org.talend.utils.test/src/org/talend/utils/wsdl/TestService.wsdl
+++ b/test/plugins/org.talend.utils.test/src/org/talend/utils/wsdl/TestService.wsdl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestService"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:tns="http://www.talend.org/service/"
+		targetNamespace="http://www.talend.org/service/">
+
+    <wsdl:import namespace="http://www.talend.org/service/binding/" location="TestServiceBinding.wsdl" />
+
+    <wsdl:types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			targetNamespace="http://www.talend.org/service/">
+			<xsd:element name="TestServiceOperationRequest">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="in" type="xsd:string"></xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="TestServiceOperationResponse">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="out" type="xsd:string"></xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:schema>
+	</wsdl:types>
+
+	<wsdl:message name="TestServiceOperationRequest">
+		<wsdl:part name="parameters" element="tns:TestServiceOperationRequest"></wsdl:part>
+	</wsdl:message>
+	<wsdl:message name="TestServiceOperationResponse">
+		<wsdl:part name="parameters" element="tns:TestServiceOperationResponse"></wsdl:part>
+	</wsdl:message>
+
+	<wsdl:portType name="TestServicePortType">
+		<wsdl:operation name="TestServiceOperation">
+			<wsdl:input message="tns:TestServiceOperationRequest"></wsdl:input>
+			<wsdl:output message="tns:TestServiceOperationResponse"></wsdl:output>
+		</wsdl:operation>
+	</wsdl:portType>
+
+	<wsdl:service name="TestService">
+		<wsdl:port name="TestServicePort" binding="tns:TestServiceBinding">
+			<soap:address location="http://localhost:8090/services/TestService" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/test/plugins/org.talend.utils.test/src/org/talend/utils/wsdl/TestServiceBinding.wsdl
+++ b/test/plugins/org.talend.utils.test/src/org/talend/utils/wsdl/TestServiceBinding.wsdl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestServiceBinding"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:svc="http://www.talend.org/service/"
+		xmlns:tns="http://www.talend.org/service/binding/"
+		targetNamespace="http://www.talend.org/service/binding/">
+
+    <wsdl:import namespace="http://www.talend.org/service/" location="TestService.wsdl" />
+
+	<wsdl:binding name="TestServiceBinding" type="svc:TestServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TestServiceOperation">
+			<soap:operation soapAction="http://www.talend.org/service/TestServiceOperation" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+</wsdl:definitions>

--- a/test/plugins/org.talend.utils.test/src/org/talend/utils/wsdl/WSDLLoaderTest.java
+++ b/test/plugins/org.talend.utils.test/src/org/talend/utils/wsdl/WSDLLoaderTest.java
@@ -1,0 +1,50 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.utils.wsdl;
+
+import static org.junit.Assert.*;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class WSDLLoaderTest {
+
+	@Test
+	public void testCircularDependencyLoading() throws Exception {
+		WSDLLoader wsdlLoader = new WSDLLoader();
+		String wsdlLocation = getClass().getResource("TestService.wsdl").toExternalForm();
+		String fileNameTemplate = "Test.%d.wsdl";
+		Map<String, InputStream> result = wsdlLoader.load(wsdlLocation, fileNameTemplate);
+		assertEquals(3, result.size());
+		String resA = readWsdlStream(result.get(WSDLLoader.DEFAULT_FILENAME));
+		assertTrue(resA.indexOf("wsdl:import") > 0);
+		assertTrue(resA.indexOf("location=\"Test.0.wsdl\"") > 0);
+		String resB = readWsdlStream(result.get("Test.0.wsdl"));
+		assertTrue(resB.indexOf("wsdl:import") > 0);
+		assertTrue(resB.indexOf("location=\"Test.1.wsdl\"") > 0);
+		String resC = readWsdlStream(result.get("Test.1.wsdl"));
+		// assertTrue(resC.indexOf("wsdl:import") > 0);
+		// assertTrue(resC.indexOf("location=\"Test.0.wsdl\"") > 0);
+		assertEquals(resA, resC);
+	}
+
+	private String readWsdlStream(InputStream wsdlStream) throws Exception {
+		assertNotNull(wsdlStream);
+		byte[] buf = new byte[2048];
+		int len = wsdlStream.read(buf);
+		assertTrue(len > 0);
+		return new String(buf, 0, len, "UTF8");
+	}
+}


### PR DESCRIPTION
Circular WSDL imports are not prohibited by WS-I basic profile. However, they are currently causing WSDL import to fail in an endless recursion. The present fix corrects this condition and ensures that WSDL documents are not imported more than once.