### PR TITLE
fix(TDI-40521) : We can send a Talend byte[] to a MS CRM String

### DIFF
--- a/main/plugins/org.talend.core.runtime/mappings/mapping_MicrosoftCrm_odata.xml
+++ b/main/plugins/org.talend.core.runtime/mappings/mapping_MicrosoftCrm_odata.xml
@@ -24,6 +24,7 @@
 				<talendType type="id_Byte" />
 				<talendType type="id_byte[]">
                     <dbType type="Binary" default="true" />
+                    <dbType type="String"/>
                 </talendType>
 				<talendType type="id_Character" />
 				<talendType type="id_Date">


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-40521

**What is the new behavior?**
We can send a byte[] into a Edm/String. It will be encoded to base 64

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


