### PR TITLE
fix(TDI-40133)Update DocumentToFlat.java

### DIFF
--- a/main/plugins/org.talend.librariesmanager/resources/java/routines/system/DocumentToFlat.java
+++ b/main/plugins/org.talend.librariesmanager/resources/java/routines/system/DocumentToFlat.java
@@ -48,7 +48,7 @@ public class DocumentToFlat {
 			loopXpath = doc.createXPath(currentLoop);
 		}
 		loopXpath.setNamespaceURIs(xmlNameSpaceMap);
-		nodes = loopXpath.selectNodes(doc);
+		nodes = convertToList(loopXpath.selectNodes(doc));
 		if(this.isOptional && nodes.size() == 0 && !top) {
 			setParentAsLoop();
 			flat();
@@ -184,7 +184,7 @@ public class DocumentToFlat {
 	public void flatForLookup(boolean isOptionalLoop) {
 		XPath loopXpath = doc.createXPath(currentLoop);
 		loopXpath.setNamespaceURIs(xmlNameSpaceMap);
-		nodes = loopXpath.selectNodes(doc);
+		nodes = convertToList(loopXpath.selectNodes(doc));
 		if(isOptionalLoop && nodes.size() == 0 && !top) {
 			setParentAsLoop();
 			flatForLookup(isOptionalLoop);
@@ -246,6 +246,14 @@ public class DocumentToFlat {
 	
 	public void setIsOptional(boolean isLoopOptional) {
 		this.isOptional = isLoopOptional;
+	}
+	
+	public List<AbstractNode> convertToList(Object nodes) {
+		if (nodes == null) {
+			return null;
+		} else {
+			return (List) nodes;
+		}
 	}
 	
 }


### PR DESCRIPTION
Fixed error when moving from dom4j-1.6.1 to dom4j-2.0.0.
error: incompatible types: List<Node> cannot be converted to List<AbstractNode>
nodes = loopXpath.selectNodes(doc);

https://jira.talendforge.org/browse/TDI-40133

@dmytro-sylaiev Can you please review my patch?