### PR TITLE
fix(TUP-20303)project folder name not correct in workspace after import

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/repository/ProjectManager.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/repository/ProjectManager.java
@@ -293,7 +293,7 @@ public final class ProjectManager {
         if (currentProject == null) {
             initCurrentProject();
         }
-        if (currentProject.getTechnicalLabel().equalsIgnoreCase(projectLabel)) {
+        if (currentProject != null && currentProject.getTechnicalLabel().equalsIgnoreCase(projectLabel)) {
             return currentProject.getEmfProject();
         }
         for (Project project : getAllReferencedProjects()) {


### PR DESCRIPTION
fix(TUP-20303)project folder name not correct in workspace after import using "Import an existing project"
https://jira.talendforge.org/browse/TUP-20303