### PR TITLE
fix(TUP-20248) shouldn't have NPE but need to be able for

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/relationship/RelationshipItemBuilder.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/relationship/RelationshipItemBuilder.java
@@ -502,7 +502,7 @@ public class RelationshipItemBuilder {
         itemToTest.setVersion(version);
         if (!itemsRelations.containsKey(itemToTest)) {
             try {
-                Item item = proxyRepositoryFactory.getLastVersion(getAimProject(), itemId).getProperty().getItem();
+                Item item = proxyRepositoryFactory.getLastRefVersion(getAimProject(), itemId).getProperty().getItem();
                 addOrUpdateItem(item, false);
             } catch (PersistenceException e) {
                 log.error(e.getMessage());

--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/repository/model/IProxyRepositoryFactory.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/repository/model/IProxyRepositoryFactory.java
@@ -273,6 +273,8 @@ public interface IProxyRepositoryFactory {
 
     public abstract IRepositoryViewObject getLastVersion(String id) throws PersistenceException;
 
+    public IRepositoryViewObject getLastRefVersion(Project project, String id) throws PersistenceException;
+
     public abstract IRepositoryViewObject getSpecificVersion(Project project, String id, String version, boolean avoidSaveProject)
             throws PersistenceException;
 


### PR DESCRIPTION
RelationshipItemBuilder can also be used for other projects instead of
current project and reference projects during git merge.