### PR TITLE
Revert "TESB-23502 Propagation of build type to child Route/Routelet Jobs is added"

### DIFF
--- a/main/plugins/org.talend.core/src/main/java/org/talend/designer/runprocess/ProcessorUtilities.java
+++ b/main/plugins/org.talend.core/src/main/java/org/talend/designer/runprocess/ProcessorUtilities.java
@@ -1110,12 +1110,6 @@ public class ProcessorUtilities {
                 argumentsMap.put(TalendProcessArgumentConstant.ARG_GENERATE_OPTION, option);
                 processor.setArguments(argumentsMap);
             }
-            
-            // TESB-23502
-            if("ROUTE".equals(getBuildType(jobInfo))) {
-                selectedProcessItem.getProperty().getAdditionalProperties().put(TalendProcessArgumentConstant.ARG_BUILD_TYPE, "ROUTE");
-            }
-            
             setNeededResources(argumentsMap, jobInfo);
 
             processor.setArguments(argumentsMap);
@@ -1148,21 +1142,6 @@ public class ProcessorUtilities {
                 TimeMeasure.display = TimeMeasure.displaySteps = TimeMeasure.measureActive = false;
             }
         }
-    }
-    
-    private static Object getBuildType(JobInfo  jobInfo) {
-        if(jobInfo == null) {
-            return null;
-        }
-        JobInfo parentJobInfo = jobInfo.getFatherJobInfo(); 
-        if(parentJobInfo == null) {
-            if(jobInfo.getArgumentsMap() != null) {
-                return jobInfo.getArgumentsMap().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE);
-            }else {
-                return null;
-            }
-        }
-        return getBuildType(parentJobInfo);
     }
 
     private static Set<ModuleNeeded> getAllJobTestcaseModules(ProcessItem selectedProcessItem) {


### PR DESCRIPTION
This change must be reverted because of it does not resolve general issue with child Routets job processing. Besides, we have minor side effect - routes are marked as modified in Studio after Route is built.