### PR TITLE
TESB-23502,  TESB-23539 Propagation of build type to child Route/Routelet Jobs is added

### DIFF
--- a/main/plugins/org.talend.core/src/main/java/org/talend/designer/runprocess/ProcessorUtilities.java
+++ b/main/plugins/org.talend.core/src/main/java/org/talend/designer/runprocess/ProcessorUtilities.java
@@ -911,6 +911,7 @@ public class ProcessorUtilities {
                 progressMonitor);
     }
 
+    @SuppressWarnings("unchecked")
     private static IProcessor generateCode(JobInfo jobInfo, String selectedContextName, boolean statistics,
             boolean trace, boolean needContext, boolean isNeedLoadmodules, int option, IProgressMonitor progressMonitor)
             throws ProcessorException {
@@ -1110,6 +1111,15 @@ public class ProcessorUtilities {
                 argumentsMap.put(TalendProcessArgumentConstant.ARG_GENERATE_OPTION, option);
                 processor.setArguments(argumentsMap);
             }
+            
+            // TESB-23502
+            if("ROUTE".equals(getBuildType(jobInfo))) {
+            	Property p = selectedProcessItem.getProperty();
+            	if (p != null && ERepositoryObjectType.PROCESS.equals(ERepositoryObjectType.getType(p))) {
+            		p.getAdditionalProperties().put(TalendProcessArgumentConstant.ARG_BUILD_TYPE, "ROUTE");
+            	}
+            }
+            
             setNeededResources(argumentsMap, jobInfo);
 
             processor.setArguments(argumentsMap);
@@ -1142,6 +1152,21 @@ public class ProcessorUtilities {
                 TimeMeasure.display = TimeMeasure.displaySteps = TimeMeasure.measureActive = false;
             }
         }
+    }
+    
+    private static Object getBuildType(JobInfo  jobInfo) {
+        if(jobInfo == null) {
+            return null;
+        }
+        JobInfo parentJobInfo = jobInfo.getFatherJobInfo(); 
+        if(parentJobInfo == null) {
+            if(jobInfo.getArgumentsMap() != null) {
+                return jobInfo.getArgumentsMap().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE);
+            }else {
+                return null;
+            }
+        }
+        return getBuildType(parentJobInfo);
     }
 
     private static Set<ModuleNeeded> getAllJobTestcaseModules(ProcessItem selectedProcessItem) {


### PR DESCRIPTION
Current solution has one minor side effect -  routes are marked as modified in Studio GUI after Route is built/executed.