### PR TITLE
fix(TUP-20758)Metadata connection to MSSQL with Integrated Security and

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/database/conn/DatabaseConnStrUtil.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/database/conn/DatabaseConnStrUtil.java
@@ -109,7 +109,11 @@ public class DatabaseConnStrUtil {
                 s = getStringReplace(s, EDatabaseConnVar.LOGIN.getVariable(), login, supportContext);
                 s = getStringReplace(s, EDatabaseConnVar.PASSWORD.getVariable(), password, supportContext, true);
                 s = getStringReplace(s, EDatabaseConnVar.HOST.getVariable(), host, supportContext);
-                s = getStringReplace(s, EDatabaseConnVar.PORT.getVariable(), port, supportContext);
+                if (checkSpecialPortEmpty(dbType, port)) {
+                    s = getStringReplace(s, ":" + EDatabaseConnVar.PORT.getVariable(), port, supportContext);
+                } else {
+                    s = getStringReplace(s, EDatabaseConnVar.PORT.getVariable(), port, supportContext);
+                }
                 s = getStringReplace(s, EDatabaseConnVar.SID.getVariable(), sid, supportContext);
                 s = getStringReplace(s, EDatabaseConnVar.SERVICE_NAME.getVariable(), sid, supportContext);
                 s = getStringReplace(s, EDatabaseConnVar.DATASOURCE.getVariable(), datasource, supportContext);
@@ -119,6 +123,21 @@ public class DatabaseConnStrUtil {
             }
         }
         return DatabaseConnConstants.EMPTY;
+    }
+
+    /**
+     * For some special DB type, the port can be empty DOC jding Comment method "checkSpecialPortEmpty".
+     * 
+     * @param dbType
+     * @param port
+     * @return
+     */
+    private static boolean checkSpecialPortEmpty(final String dbType, final String port) {
+        boolean isSpecial = false;
+        if (EDatabaseTypeName.MSSQL.getDisplayName().equals(dbType) && StringUtils.isBlank(port)) {
+            isSpecial = true;
+        }
+        return isSpecial;
     }
 
     public static String getURLString(final String dbType, final String dbVersion, final String host, final String login,

--- a/test/plugins/org.talend.core.runtime.test/src/org/talend/core/database/conn/DatabaseConnStrUtilTest.java
+++ b/test/plugins/org.talend.core.runtime.test/src/org/talend/core/database/conn/DatabaseConnStrUtilTest.java
@@ -12,9 +12,11 @@
 // ============================================================================
 package org.talend.core.database.conn;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.talend.core.database.EDatabaseTypeName;
+import org.talend.core.database.conn.version.EDatabaseVersion4Drivers;
 import org.talend.core.model.metadata.builder.connection.ConnectionFactory;
 import org.talend.core.model.metadata.builder.connection.DatabaseConnection;
 import org.talend.core.model.metadata.connection.hive.HiveModeInfo;
@@ -111,5 +113,25 @@ public class DatabaseConnStrUtilTest {
         expectValue = "jdbc:hive2://" + server + ":" + port + "/" + sidOrDatabase + ";" + additionalJDBCSettings;
         realValue = DatabaseConnStrUtil.getHiveURLString(dc, server, port, sidOrDatabase, HIVE2_STANDARDLONE_URL);
         assertTrue(expectValue.equals(realValue));
+    }
+
+    @Test
+    public void testGetURLStringForMSSQL() {
+        String dbType = EDatabaseTypeName.MSSQL.getDisplayName();
+        String dbVersion = EDatabaseVersion4Drivers.MSSQL_PROP.getVersionValue();
+        String host = "lcoalhost";
+        String port = "";
+        String sid = "master";
+        String[] otherParam = new String[] {};
+        String expectURL = "jdbc:sqlserver://" + host + ";DatabaseName=master;";
+        String realValue = DatabaseConnStrUtil.getURLString(false, dbType, dbVersion, host, "", "", port, sid, "", "", "", "",
+                otherParam);
+        assertTrue(expectURL.equals(realValue));
+
+        port = "1433";
+        expectURL = "jdbc:sqlserver://" + host + ":" + port + ";DatabaseName=master;";
+        realValue = DatabaseConnStrUtil.getURLString(false, dbType, dbVersion, host, "", "", port, sid, "", "", "", "",
+                otherParam);
+        assertTrue(expectURL.equals(realValue));
     }
 }


### PR DESCRIPTION
(#1870)

* fix(TUP-20758)Metadata connection to MSSQL with Integrated Security
and
TCP Dynamic ports
https://jira.talendforge.org/browse/TUP-20758

* fix(TUP-20758)Metadata connection to MSSQL with Integrated Security
and
TCP Dynamic ports
https://jira.talendforge.org/browse/TUP-20758
Add a junit

* fix(TUP-20758)Metadata connection to MSSQL with Integrated Security
and
TCP Dynamic ports
https://jira.talendforge.org/browse/TUP-20758

Conflicts:
	test/plugins/org.talend.core.runtime.test/src/org/talend/core/database/conn/DatabaseConnStrUtilTest.java