### PR TITLE
fix(TDI-41180): add netsuite 2018 runtime dependency

### DIFF
--- a/main/plugins/org.talend.designer.maven.tos/resources/components/pom.xml
+++ b/main/plugins/org.talend.designer.maven.tos/resources/components/pom.xml
@@ -98,6 +98,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.talend.components</groupId>
+			<artifactId>components-netsuite-runtime_2018_2</artifactId>
+			<version>${components.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.talend.components</groupId>
 			<artifactId>components-marketo-runtime</artifactId>
 			<version>${components.version}</version>
 		</dependency>


### PR DESCRIPTION
Add runtime components-netsuite-runtime_2018_2 dependency for NetSuite component.