### PR TITLE
fix(TUP-20862): Folder in "poms\jobs" won't be updated after move around spark job folders in studio repository

### DIFF
--- a/main/plugins/org.talend.core.repository/src/main/java/org/talend/core/repository/model/ProxyRepositoryFactory.java
+++ b/main/plugins/org.talend.core.repository/src/main/java/org/talend/core/repository/model/ProxyRepositoryFactory.java
@@ -140,6 +140,7 @@ import org.talend.repository.documentation.ERepositoryActionName;
 import org.talend.repository.model.IProxyRepositoryFactory;
 import org.talend.repository.model.RepositoryConstants;
 import org.talend.utils.io.FilesUtils;
+
 import orgomg.cwm.objectmodel.core.ModelElement;
 
 /**
@@ -637,13 +638,17 @@ public final class ProxyRepositoryFactory implements IProxyRepositoryFactory {
             throw new PersistenceException(Messages.getString("ProxyRepositoryFactory.MoveFolderContainsLockedItem")); //$NON-NLS-1$
         }
         this.repositoryFactoryFromProvider.moveFolder(type, sourcePath, targetPath);
-        if (type == ERepositoryObjectType.PROCESS) {
-            fireRepositoryPropertyChange(ERepositoryActionName.FOLDER_MOVE.getName(), new IPath[] { sourcePath, targetPath },
-                    type);
-        }
-        if (ERepositoryObjectType.getAllTypesOfJoblet().contains(type)) {
-            fireRepositoryPropertyChange(ERepositoryActionName.JOBLET_FOLDER_MOVE.getName(),
-                    new IPath[] { sourcePath, targetPath }, type);
+        if (type != null) {
+            /*
+             * MUST check joblet first, since getAllTypesOfProcess2 contains joblet
+             */
+            if (ERepositoryObjectType.getAllTypesOfJoblet().contains(type)) {
+                fireRepositoryPropertyChange(ERepositoryActionName.JOBLET_FOLDER_MOVE.getName(),
+                        new IPath[] { sourcePath, targetPath }, type);
+            } else if (ERepositoryObjectType.getAllTypesOfProcess2().contains(type)) {
+                fireRepositoryPropertyChange(ERepositoryActionName.FOLDER_MOVE.getName(), new IPath[] { sourcePath, targetPath },
+                        type);
+            }
         }
         this.repositoryFactoryFromProvider.updateItemsPath(type, targetPath.append(sourcePath.lastSegment()));
     }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TUP-20862