### PR TITLE
fix(TUP-20244)Guess query is not correct for tHiveInput if hivetable name is used a context value 

### DIFF
--- a/main/plugins/org.talend.core/src/main/java/org/talend/core/model/metadata/query/AbstractQueryGenerator.java
+++ b/main/plugins/org.talend.core/src/main/java/org/talend/core/model/metadata/query/AbstractQueryGenerator.java
@@ -417,7 +417,9 @@ public abstract class AbstractQueryGenerator implements IQueryGenerator {
             final String tableNameWithDBAndSchema = getTableNameWithDBAndSchema(dbName, schemaName, tableName);
             String columnField = generateColumnFields(tableNameWithDBAndSchema);
             if (dbType == EDatabaseTypeName.HIVE) {
-                columnField = generateColumnFields(tableName);
+                columnField = ContextParameterUtils.containContextVariables(tableName)
+                        ? generateColumnFields(SQL_START_CONNECTION + tableName + SQL_END_CONNECTION)
+                        : generateColumnFields(tableName);
             }
 
             StringBuffer sql = new StringBuffer(100);

--- a/main/plugins/org.talend.core/src/main/java/org/talend/core/model/metadata/query/IQueryGenerator.java
+++ b/main/plugins/org.talend.core/src/main/java/org/talend/core/model/metadata/query/IQueryGenerator.java
@@ -32,6 +32,10 @@ public interface IQueryGenerator {
 
     public static final String SQL_FROM = "FROM"; //$NON-NLS-1$
 
+    public static final String SQL_START_CONNECTION = "\"+";
+
+    public static final String SQL_END_CONNECTION = "+\"";
+
     public void setParameters(IElement element, IMetadataTable metadataTable, String schema, String realTableName);
 
     public void setParameters(IElement element, IMetadataTable metadataTable, String schema, String realTableName, boolean isJdbc);


### PR DESCRIPTION
Guess query is not correct for tHiveInput if hivetable name is used a context value(#2061)

* fix(TUP-20244)Guess query is not correct for tHiveInput if hivetable
name is used a context value

* fix(TUP-20244)Guess query is not correct for tHiveInput if hivetable
name is used a context value