### PR TITLE
fix(TESB-24543): Fix NPE on WSDL import with several schemas in one TNS.

### DIFF
--- a/main/plugins/org.talend.metadata.managment.ui/src/main/java/org/talend/metadata/managment/ui/utils/XsdMetadataUtils.java
+++ b/main/plugins/org.talend.metadata.managment.ui/src/main/java/org/talend/metadata/managment/ui/utils/XsdMetadataUtils.java
@@ -218,6 +218,10 @@ public final class XsdMetadataUtils {
                     break;
                 }
             }
+            if (node == null) {
+                // no declaration in the present XSD
+                return;
+            }
             node = populationUtil.getSchemaTree(xsdSchema, node);
             orderId = 1;
             loopElementFound = false;


### PR DESCRIPTION
The present fix handles the condition that with the import of several schemas of the same target namespace, not all types and elements are necessarily resolved in the scope of on XSD import.