### PR TITLE
Fix TUP-21115 Enable secure processing disallow doctypes for DocumentBuilderFactory instances

### DIFF
--- a/main/plugins/org.talend.commons.runtime/src/org/talend/commons/runtime/xml/XSDValidator.java
+++ b/main/plugins/org.talend.commons.runtime/src/org/talend/commons/runtime/xml/XSDValidator.java
@@ -40,7 +40,7 @@ public class XSDValidator {
 
     public static Document checkXSD(File fileToCheck, File fileXSD) throws IOException, ParserConfigurationException,
             SAXException {
-        final DocumentBuilderFactory fabrique = XmlUtils.getSecureDocumentBuilderFactory();
+        final DocumentBuilderFactory fabrique = XmlUtils.getSecureDocumentBuilderFactory(false);
         fabrique.setAttribute(SCHEMA_LANGUAGE, "http://www.w3.org/2001/XMLSchema"); //$NON-NLS-1$
         fabrique.setAttribute(SCHEMA_VALIDATOR, fileXSD);
         fabrique.setValidating(true);


### PR DESCRIPTION
Fix TUP-21115 Enable secure processing disallow doctypes for DocumentBuilderFactory instances https://jira.talendforge.org/browse/TUP-21115 (XSDValidator open Doctype
option)