### PR TITLE
fix(TUP-21880):Quick tour page is blank when launch studio using ESB

### DIFF
--- a/main/plugins/org.talend.presentation.onboarding/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.presentation.onboarding/META-INF/MANIFEST.MF
@@ -19,8 +19,7 @@ Require-Bundle: org.apache.log4j,
  org.eclipse.ui.intro,
  org.eclipse.ui.workbench,
  org.talend.libraries.jackson,
- org.w3c.css.sac,
- org.talend.utils
+ org.w3c.css.sac
 Bundle-ActivationPolicy: lazy
 Export-Package: org.talend.presentation.onboarding.interfaces,
  org.talend.presentation.onboarding.ui.managers,

--- a/main/plugins/org.talend.presentation.onboarding/src/org/talend/presentation/onboarding/utils/OnBoardingUtils.java
+++ b/main/plugins/org.talend.presentation.onboarding/src/org/talend/presentation/onboarding/utils/OnBoardingUtils.java
@@ -44,7 +44,6 @@ import org.talend.presentation.onboarding.ui.managers.OnBoardingResourceManager;
 import org.talend.presentation.onboarding.ui.runtimedata.OnBoardingJsonDoc;
 import org.talend.presentation.onboarding.ui.runtimedata.OnBoardingPerspectiveBean;
 import org.talend.presentation.onboarding.ui.runtimedata.OnBoardingRegistedResource;
-import org.talend.utils.xml.XmlUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -256,7 +255,8 @@ public class OnBoardingUtils {
     public static Document convertStringToDocument(String htmlStr) {
         Document newDoc = null;
         try {
-            DocumentBuilderFactory factory = XmlUtils.getSecureDocumentBuilderFactory();
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); //$NON-NLS-1$
             factory.setValidating(false);
             // if this is not set, Document.getElementsByTagNameNS() will fail.
             factory.setNamespaceAware(true);

--- a/main/plugins/org.talend.presentation.onboarding/src/org/talend/presentation/onboarding/utils/OnBoardingUtils.java
+++ b/main/plugins/org.talend.presentation.onboarding/src/org/talend/presentation/onboarding/utils/OnBoardingUtils.java
@@ -255,8 +255,13 @@ public class OnBoardingUtils {
     public static Document convertStringToDocument(String htmlStr) {
         Document newDoc = null;
         try {
+            // Fixed in TUP-21880. As set XMLConstants.FEATURE_SECURE_PROCESSING feature to true will cause page display
+            // trouble in our studio's Quick tour page.
+            // Now we won't set the XMLConstants.FEATURE_SECURE_PROCESSING feature to true for this onBoardingView.html
+            // file.
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); //$NON-NLS-1$
+            factory.setNamespaceAware(true);
             factory.setValidating(false);
             // if this is not set, Document.getElementsByTagNameNS() will fail.
             factory.setNamespaceAware(true);


### PR DESCRIPTION
license

For the html file DocumentBuilderfactory, we shouldn't set
XMLConstants.FEATURE_SECURE_PROCESSING feature to true.
https://jira.talendforge.org/browse/TUP-21880