### PR TITLE
TUP-22340 Missing jobs after importing with studio build after eclipse upgrade

### DIFF
--- a/main/plugins/org.talend.libraries.apache/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.libraries.apache/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Bundle-Vendor: .Talend SA.
 Require-Bundle: org.apache.log4j;resolution:=optional,
  org.talend.libraries.apache.common;visibility:=reexport,
  jackson-core-asl;bundle-version="1.9.13",
- jackson-mapper-asl;bundle-version="1.9.13"
+ jackson-mapper-asl;bundle-version="1.9.13",
+ org.apache.xerces
 Export-Package: 
  org.apache.james.mime4j,
  org.apache.james.mime4j.codec,


### PR DESCRIPTION
TUP-22340 Missing jobs after importing with studio build after eclipse upgrade
https://jira.talendforge.org/browse/TUP-22340