### PR TITLE
Fix TUP-23244 Studio continuously throw "Attach is not supported for

### DIFF
--- a/main/plugins/org.talend.core.ui/src/main/java/org/talend/core/ui/properties/tab/HorizontalTabFactory.java
+++ b/main/plugins/org.talend.core.ui/src/main/java/org/talend/core/ui/properties/tab/HorizontalTabFactory.java
@@ -48,7 +48,6 @@ public class HorizontalTabFactory {
     public void initComposite(Composite parent, boolean displayCompactToolbar) {
 
         Composite panel = new Composite(parent, SWT.NONE);
-        panel.setLayoutData(new GridData(GridData.FILL_BOTH));
         panel.setLayout(new FormLayout());
 
         widgetFactory = new TabbedPropertySheetWidgetFactory();


### PR DESCRIPTION
Fix TUP-23244 Studio continuously throw "Attach is not supported for target JVM" after memory run
https://jira.talendforge.org/browse/TUP-23244