### PR TITLE
Fix TUP-23170 New branch with name "/" will lead job with reference

### DIFF
--- a/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/tools/BuildCacheManager.java
+++ b/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/tools/BuildCacheManager.java
@@ -278,6 +278,7 @@ public class BuildCacheManager {
 
     public void clearAllCaches() {
         jobCache.clear();
+        clearCurrentJobletCache();
         jobletCache.clear();
         codesLastBuildCache.clear();
     }


### PR DESCRIPTION
Fix TUP-23170 New branch with name "/" will lead job with reference joblet build failure (Fix can't clean joblet cache problem)
https://jira.talendforge.org/browse/TUP-23170