### PR TITLE
bugfix(TUP-24563):Specifying a custom MVN URI in a Bean still ends up

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/ILibraryManagerService.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/ILibraryManagerService.java
@@ -89,6 +89,8 @@ public interface ILibraryManagerService extends IService {
      * @return
      */
     public boolean retrieve(String jarNeeded, String pathToStore, IProgressMonitor... monitorWrap);
+    
+    public boolean retrieve(String jarNeeded, String jarURL, String pathToStore, IProgressMonitor... monitorWrap);
 
     public boolean retrieve(String jarNeeded, String pathToStore, boolean showDialog, IProgressMonitor... monitorWrap);
 

--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/LocalLibraryManager.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/model/service/LocalLibraryManager.java
@@ -299,6 +299,17 @@ public class LocalLibraryManager implements ILibraryManagerService, IChangedLibr
         return retrieve(testModule, pathToStore, popUp, refresh);
     }
 
+	@Override
+	public boolean retrieve(String jarNeeded, String mavenUri, String pathToStore, IProgressMonitor... monitorWrap) {
+		ModuleNeeded testModule = new ModuleNeeded("", jarNeeded, "", true);
+		if(mavenUri != null) {
+			testModule.setMavenUri(mavenUri);
+		}
+        boolean refresh = true;
+        return retrieve(testModule, pathToStore, true, refresh);
+	}
+
+
     private boolean retrieve(ModuleNeeded module, String pathToStore, boolean showDialog, boolean refresh) {
         String jarNeeded = module.getModuleName();
         String sourcePath = null;


### PR DESCRIPTION
turning into a reference to the default 6.0.0-SNAPSHOT version