### PR TITLE
fix(TUP-18610):When drag hdfs to spark job,hadoop cluster some contex…

### DIFF
--- a/main/plugins/org.talend.metadata.managment.ui/src/main/java/org/talend/metadata/managment/ui/utils/ConnectionContextHelper.java
+++ b/main/plugins/org.talend.metadata.managment.ui/src/main/java/org/talend/metadata/managment/ui/utils/ConnectionContextHelper.java
@@ -764,7 +764,25 @@ public final class ConnectionContextHelper {
                     Connection hadoopClusterConnection = hadoopClusterItem.getConnection();
                     ContextItem hadoopClusterContextItem = ContextUtils.getContextItemById2(hadoopClusterConnection
                             .getContextId());
-                    Set<String> hcNeededVars = retrieveContextVar(elementParameters, hadoopClusterConnection, category, true);
+                    Set<String> hcNeededVars = retrieveContextVar(elementParameters, hadoopClusterConnection, category, false);
+                    // The tSparkConfiguration & tHadoopConfManager are singleton in process.
+                    List<INode> nodesOfType = new ArrayList<INode>();
+                    List<? extends INode> spakconfNodes = process.getNodesOfType("tSparkConfiguration"); //$NON-NLS-1$
+                    if (spakconfNodes != null && !spakconfNodes.isEmpty()) {
+                        nodesOfType.addAll(spakconfNodes);
+                    }
+                    List<? extends INode> hadoopconfNodes = process.getNodesOfType("tHadoopConfManager"); //$NON-NLS-1$
+                    if (hadoopconfNodes != null && !hadoopconfNodes.isEmpty()) {
+                        nodesOfType.addAll(hadoopconfNodes);
+                    }
+                    for (INode node : nodesOfType) {
+                        Set<String> envirNeededVars = retrieveContextVar(node.getElementParameters(), hadoopClusterConnection,
+                                category, false);
+                        if (envirNeededVars != null && !envirNeededVars.isEmpty()) {
+                            hcNeededVars.addAll(envirNeededVars);
+                        }
+                    }
+
                     List<ContextItem> contextItems = new ArrayList<>();
                     if (contextItem != null || hadoopClusterContextItem != null) {
                         // find added variables


### PR DESCRIPTION
…t (#2932)

* fix(TUP-18610):When drag hdfs to spark job,hadoop cluster some context
parameters cann't drag to job
https://jira.talendforge.org/browse/TUP-18610

* fix(TUP-18610)When drag hdfs to job,hadoop cluster some context
parameters cann't drag to job
https://jira.talendforge.org/browse/TUP-18610

* fix(TUP-18610)When drag hdfs to spark job,hadoop cluster some context
parameters cann't drag to job
https://jira.talendforge.org/browse/TUP-18610

* fix(TUP-18610)When drag hdfs to spark job,hadoop cluster some context

parameters cann't drag to job
https://jira.talendforge.org/browse/TUP-18610

Co-authored-by: Chao MENG <cmeng@talend.com>