### PR TITLE
feat(TUP-25226): Make the hadoop conf jar path a contextualizable par…

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/database/conn/ConnParameterKeys.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/database/conn/ConnParameterKeys.java
@@ -302,4 +302,11 @@ public class ConnParameterKeys {
 
     public static final String CONN_PARA_KEY_DATABRICKS_DBFS_DEP_FOLDER="CONN_PARA_KEY_DATABRICKS_DBFS_DEP_FOLDER";
 
+    /**
+     * Override hadoop configuration
+     */
+    public static final String CONN_PARA_KEY_SET_HADOOP_CONF = "CONN_PARA_KEY_SET_HADOOP_CONF";
+
+    public static final String CONN_PARA_KEY_HADOOP_CONF_SPECIFIC_JAR = "CONN_PARA_KEY_HADOOP_CONF_SPECIFIC_JAR";
+
 }

--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/hadoop/HadoopConfJarBean.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/hadoop/HadoopConfJarBean.java
@@ -1,0 +1,92 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.core.hadoop;
+
+/**
+ * DOC cmeng  class global comment. Detailled comment
+ */
+public class HadoopConfJarBean {
+
+    private boolean overrideCustomConf;
+
+    private boolean isContextMode;
+
+    /**
+     * value saved in connection, it may be a context
+     */
+    private String overrideCustomConfPath;
+
+    /**
+     * original value of the path, if connection is in context mode, then this value if the default value of the context
+     */
+    private String originalOverrideCustomConfPath;
+
+    private String customConfJarName;
+
+    public HadoopConfJarBean(boolean isContextMode, boolean overrideCustomConf, String overrideCustomConfPath,
+            String originalOverrideCustomConfPath, String customConfJarName) {
+        this.isContextMode = isContextMode;
+        this.overrideCustomConf = overrideCustomConf;
+        this.overrideCustomConfPath = overrideCustomConfPath;
+        this.originalOverrideCustomConfPath = originalOverrideCustomConfPath;
+        this.customConfJarName = customConfJarName;
+    }
+
+    public boolean isContextMode() {
+        return isContextMode;
+    }
+
+    public void setContextMode(boolean isContextMode) {
+        this.isContextMode = isContextMode;
+    }
+
+    public boolean isOverrideCustomConf() {
+        return overrideCustomConf;
+    }
+
+    public void setOverrideCustomConf(boolean overrideCustomConf) {
+        this.overrideCustomConf = overrideCustomConf;
+    }
+
+    public String getOriginalOverrideCustomConfPath() {
+        return originalOverrideCustomConfPath;
+    }
+
+    public void setOriginalOverrideCustomConfPath(String originalOverrideCustomConfPath) {
+        this.originalOverrideCustomConfPath = originalOverrideCustomConfPath;
+    }
+
+    public String getOverrideCustomConfPath() {
+        return overrideCustomConfPath;
+    }
+
+    public void setOverrideCustomConfPath(String overrideCustomConfPath) {
+        this.overrideCustomConfPath = overrideCustomConfPath;
+    }
+
+    public String getCustomConfJarName() {
+        return customConfJarName;
+    }
+
+    public void setCustomConfJarName(String customConfJarName) {
+        this.customConfJarName = customConfJarName;
+    }
+
+    @Override
+    public String toString() {
+        return "HadoopConfJarBean [overrideCustomConf=" + overrideCustomConf + ", isContextMode=" + isContextMode
+                + ", overrideCustomConfPath=" + overrideCustomConfPath + ", originalOverrideCustomConfPath="
+                + originalOverrideCustomConfPath + ", customConfJarName=" + customConfJarName + "]";
+    }
+
+}

--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/hadoop/IHadoopClusterService.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/hadoop/IHadoopClusterService.java
@@ -14,6 +14,7 @@ package org.talend.core.hadoop;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.core.runtime.IPath;
 import org.talend.commons.exception.BusinessException;
@@ -232,11 +233,12 @@ public interface IHadoopClusterService extends IService {
      */
     public Item getHadoopClusterItemById(String id);
 
-    public String getCustomConfsJarName(String id);
+    public Optional<HadoopConfJarBean> getCustomConfsJar(String id);
 
-    public String getCustomConfsJarName(String id, boolean createJarIfNotExist, boolean addExtraIds);
+    public Optional<HadoopConfJarBean> getCustomConfsJar(String id, boolean createJarIfNotExist, boolean addExtraIds);
 
-    public String getCustomConfsJarName(ConnectionItem connectionItem, boolean createJarIfNotExist, boolean addExtraIds);
+    public Optional<HadoopConfJarBean> getCustomConfsJar(ConnectionItem connectionItem, boolean createJarIfNotExist,
+            boolean addExtraIds);
 
     public void useCustomConfsJarIfNeeded(List<ModuleNeeded> modulesNeeded, String clusterId);
 

--- a/main/plugins/org.talend.metadata.managment.ui/src/main/java/org/talend/metadata/managment/ui/utils/ExtendedNodeConnectionContextUtils.java
+++ b/main/plugins/org.talend.metadata.managment.ui/src/main/java/org/talend/metadata/managment/ui/utils/ExtendedNodeConnectionContextUtils.java
@@ -125,11 +125,16 @@ public class ExtendedNodeConnectionContextUtils {
         QuboleS3BucketKey,
         QuboleS3Region,
 
+        // Override hadoop configuration
+        setHadoopConf,
+        hadoopConfSpecificJar,
+
         // DataBricks
         DataBricksEndpoint,
         DataBricksClusterId,
         DataBricksToken,
         DataBricksDBFSDepFolder
+
     }
 
     static List<IContextParameter> getContextVariables(final String prefixName, Connection conn, Set<IConnParamName> paramSet) {


### PR DESCRIPTION
…ameter in the Hadoop conf wizard (#2890)

* feat(TUP-25226): Make the hadoop conf jar path a contextualizable
parameter in the Hadoop conf wizard

https://jira.talendforge.org/browse/TUP-25226

* feat(TUP-25226): Make the hadoop conf jar path a contextualizable
parameter in the Hadoop conf wizard

https://jira.talendforge.org/browse/TUP-25226

* feat(TUP-25226): Make the hadoop conf jar path a contextualizable
parameter in the Hadoop conf wizard

https://jira.talendforge.org/browse/TUP-25226

* feat(TUP-25226): Make the hadoop conf jar path a contextualizable
parameter in the Hadoop conf wizard

https://jira.talendforge.org/browse/TUP-25226

* Revert "feat(TUP-25226): Make the hadoop conf jar path a contextualizable parameter in the Hadoop conf wizard"

This reverts commit 253b1d735abcf8fda96edf9c9e3b9145be3c891b.

* Revert "feat(TUP-25226): Make the hadoop conf jar path a contextualizable parameter in the Hadoop conf wizard"

This reverts commit 1b97430f5330cd753945c803705204f0dc2da314.

* Revert "feat(TUP-25226): Make the hadoop conf jar path a contextualizable parameter in the Hadoop conf wizard"

This reverts commit cc3c7d2ddf61a58aabae64200d5dba829b35bf52.