### PR TITLE
fix(TBD-9863): jar conflict on CDH 6.x

### DIFF
--- a/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/ClasspathsJarGenerator.java
+++ b/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/ClasspathsJarGenerator.java
@@ -110,7 +110,7 @@ public class ClasspathsJarGenerator {
         for (String cp : classpathArray) {
             Path path = new Path(cp);
             if ((path.lastSegment().startsWith("hadoop-common") || path.lastSegment().startsWith("hadoop-mapreduce-client-core") //$NON-NLS-1$//$NON-NLS-2$
-                    || path.lastSegment().startsWith("hadoop-core")) //$NON-NLS-1$
+                    || path.lastSegment().startsWith("hadoop-core") || path.lastSegment().startsWith("commons-lang3")) //$NON-NLS-1$//$NON-NLS-2$
                     && path.lastSegment().endsWith(".jar")) { //$NON-NLS-1$
                 // files should be start with /
                 if (!isRelativePath) {


### PR DESCRIPTION
hive-exec jar is loaded before commons-lang3 but hive-exec is a fatjar that contains an old version of commons-lang3
hence a lot of job are failing because this breaks all the tFileOutput components

https://jira.talendforge.org/browse/TBD-9863