### PR TITLE
TESB-28050 External jar in Cconfig would not be uploaded for the first time when add the jar in dependencies

### DIFF
--- a/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/prefs/LibrariesManagerUtils.java
+++ b/main/plugins/org.talend.librariesmanager/src/main/java/org/talend/librariesmanager/prefs/LibrariesManagerUtils.java
@@ -98,11 +98,18 @@ public class LibrariesManagerUtils {
                     && module.isRequired(node.getElementParameters())) {
                 boolean isNeedtoBeRemoved = service == null ? false
                         : isNeedtoBeRemoved(module, service.getNeedRemoveModulesForLog4j());
-                if (!isNeedtoBeRemoved) {
-                    updatedModules.add(module);
-                }
+        		if(node.getComponent().getName().equals("cConfig")) {
+        			if(module.getMavenURIFromConfiguration() == null) {
+                			if (!isNeedtoBeRemoved) {
+			                    updatedModules.add(module);
+			                }
+        			};
+        		} else {
+		                if (!isNeedtoBeRemoved) {
+		                    updatedModules.add(module);
+		                }
+        		}
             }
-
         }
         return updatedModules;
     }


### PR DESCRIPTION
The reason of this bug https://jira.talendforge.org/browse/TESB-28050
is that when we are adding external library with custom Maven URI to cConfig component, this library needs to be installed.
But method getNotInstalledModules returns not one, but two libraries with same names and different Maven URIs:
first
mavenUri - mvn:org.talend.libraries/s2jdbc-gen-2.10.48//jar"
mavenUriFromConfiguration - mvn:org.talend.libraries/s2jdbc-gen-2.10.48//jar"
and second
mavenUri - mvn:org.talend.libraries/s2jdbc-gen-2.10.48/6.0.0-SNAPSHOT/jar"
mavenUriFromConfiguration - null
That's why we need to upload both of those libraries, and we are getting behaviour described in bug.
To avoid this, we can upload only library (represented by ModuleNeeded class in application) with correct mavenUri, which is corresponded to mavenUriFromConfiguration == null