### PR TITLE
TUP-25935 Studio logon remote project can not reach user custom library

### DIFF
--- a/main/plugins/org.talend.updates.runtime/src/main/java/org/talend/updates/runtime/engine/factory/ComponentsLocalNexusInstallFactory.java
+++ b/main/plugins/org.talend.updates.runtime/src/main/java/org/talend/updates/runtime/engine/factory/ComponentsLocalNexusInstallFactory.java
@@ -78,6 +78,13 @@ public class ComponentsLocalNexusInstallFactory extends ComponentsNexusInstallFa
         if (monitor.isCanceled()) {
             throw new OperationCanceledException();
         }
+
+        if (!syncManager.isRepositoryServerAvailable(monitor, getIndexArtifact())) {
+            if (isTalendDebug) {
+                log.info("Failed to sync component index file: " + getIndexArtifact());
+            }
+            return Collections.EMPTY_SET;
+        }
         File indexFile = null;
         try {
             indexFile = syncManager.downloadIndexFile(monitor, getIndexArtifact());

--- a/main/plugins/org.talend.updates.runtime/src/main/java/org/talend/updates/runtime/nexus/component/ComponentSyncManager.java
+++ b/main/plugins/org.talend.updates.runtime/src/main/java/org/talend/updates/runtime/nexus/component/ComponentSyncManager.java
@@ -90,6 +90,9 @@ public class ComponentSyncManager {
     }
 
     public boolean isRepositoryServerAvailable(IProgressMonitor progress, MavenArtifact artifact) throws Exception {
+        if (getServerBean() == null) {
+            return false;
+        }
         IRepositoryArtifactHandler artifactHandler = null;
         boolean isSnapshot = isSnapshot(artifact);
         if (isSnapshot) {


### PR DESCRIPTION
TUP-25935 Studio logon remote project can not reach user custom library will throw error log like
ComponentSyncManager.getSnapshotRepositoryHandler.
https://jira.talendforge.org/browse/TUP-25935