### PR TITLE
fix(TUP-26165):fix jar with classifier missing issue (#3152)

### DIFF
--- a/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/tools/creator/CreateMavenJobPom.java
+++ b/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/tools/creator/CreateMavenJobPom.java
@@ -55,6 +55,7 @@ import org.talend.core.model.process.ProcessUtils;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.core.model.properties.Project;
 import org.talend.core.model.properties.Property;
+import org.talend.core.model.repository.ERepositoryObjectType;
 import org.talend.core.model.utils.JavaResourcesHelper;
 import org.talend.core.repository.utils.ItemResourceUtil;
 import org.talend.core.runtime.maven.MavenArtifact;
@@ -77,7 +78,6 @@ import org.talend.designer.maven.template.ETalendMavenVariables;
 import org.talend.designer.maven.template.MavenTemplateManager;
 import org.talend.designer.maven.utils.PomIdsHelper;
 import org.talend.designer.maven.utils.PomUtil;
-import org.talend.designer.maven.utils.SortableDependency;
 import org.talend.designer.runprocess.IProcessor;
 import org.talend.designer.runprocess.IRunProcessService;
 import org.talend.repository.ProjectManager;
@@ -622,9 +622,9 @@ public class CreateMavenJobPom extends AbstractMavenProcessorPom {
             Property property = jobInfo.getProcessItem().getProperty();
             String coordinate =
                     getCoordinate(PomIdsHelper.getJobGroupId(property), PomIdsHelper.getJobArtifactId(jobInfo),
-                            MavenConstants.PACKAGING_JAR, PomIdsHelper.getJobVersion(property));
-            Dependency dependency = getDependencyObject(PomIdsHelper.getJobGroupId(property), PomIdsHelper.getJobArtifactId(jobInfo), PomIdsHelper.getJobVersion(property),
-                            MavenConstants.PACKAGING_JAR, null);
+                            MavenConstants.PACKAGING_JAR, PomIdsHelper.getJobVersion(property), null);
+            Dependency dependency = PomUtil.createDependency(PomIdsHelper.getJobGroupId(property),
+                    PomIdsHelper.getJobArtifactId(jobInfo), PomIdsHelper.getJobVersion(property), MavenConstants.PACKAGING_JAR);
             jobCoordinateMap.put(coordinate, dependency);
         }
 
@@ -632,9 +632,10 @@ public class CreateMavenJobPom extends AbstractMavenProcessorPom {
         Property parentProperty = this.getJobProcessor().getProperty();
         String parentCoordinate =
                 getCoordinate(PomIdsHelper.getJobGroupId(parentProperty), PomIdsHelper.getJobArtifactId(parentProperty),
-                        MavenConstants.PACKAGING_JAR, PomIdsHelper.getJobVersion(parentProperty));
-        Dependency parentDependency = getDependencyObject(PomIdsHelper.getJobGroupId(parentProperty), PomIdsHelper.getJobArtifactId(parentProperty), PomIdsHelper.getJobVersion(parentProperty),
-                        MavenConstants.PACKAGING_JAR, null);
+                        MavenConstants.PACKAGING_JAR, PomIdsHelper.getJobVersion(parentProperty), null);
+        Dependency parentDependency = PomUtil.createDependency(PomIdsHelper.getJobGroupId(parentProperty),
+                PomIdsHelper.getJobArtifactId(parentProperty), PomIdsHelper.getJobVersion(parentProperty),
+                MavenConstants.PACKAGING_JAR);
         jobCoordinateMap.put(parentCoordinate, parentDependency);
 
         // add talend libraries and codes
@@ -698,10 +699,11 @@ public class CreateMavenJobPom extends AbstractMavenProcessorPom {
             }
             MavenArtifact artifact = MavenUrlHelper.parseMvnUrl(moduleNeeded.getMavenUri());
             String coordinate = getCoordinate(artifact.getGroupId(), artifact.getArtifactId(), artifact.getType(),
-                    artifact.getVersion());
+                    artifact.getVersion(), artifact.getClassifier());
             if (!jobCoordinateMap.containsKey(coordinate) && !talendLibCoordinateMap.containsKey(coordinate)
                     && !_3rdDepLibMap.containsKey(coordinate)) {
-                Dependency dependencyObject = getDependencyObject(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(), artifact.getType(), artifact.getClassifier());
+                Dependency dependencyObject = PomUtil.createDependency(artifact.getGroupId(), artifact.getArtifactId(),
+                        artifact.getVersion(), artifact.getType(), artifact.getClassifier());
                 if (MavenConstants.DEFAULT_LIB_GROUP_ID.equals(artifact.getGroupId())
                         || artifact.getGroupId().startsWith(projectGroupId)) {
                     talendLibCoordinateMap.put(coordinate, dependencyObject);
@@ -714,6 +716,23 @@ public class CreateMavenJobPom extends AbstractMavenProcessorPom {
                 }
             }
         }
+        
+        try {
+            Set<Dependency> codesDependencies = new HashSet<Dependency>();
+            for (ERepositoryObjectType type : ERepositoryObjectType.getAllTypesOfCodes()) {
+                codesDependencies.addAll(PomUtil.getCodesDependencies(type));
+            }
+            for (Dependency codeDependency : codesDependencies) {
+                Dependency dependency = PomUtil.createDependency(codeDependency.getGroupId(), codeDependency.getArtifactId(),
+                        codeDependency.getVersion(), codeDependency.getType(), codeDependency.getClassifier());
+                if (dependency != null) {
+                    addToDuplicateLibs(duplicateLibs, dependency);
+                }
+            }
+        } catch (CoreException e1) {
+            ExceptionHandler.process(e1);
+        }
+
 
         Iterator<String> iterator = duplicateLibs.keySet().iterator();
         while (iterator.hasNext()) {
@@ -750,10 +769,11 @@ public class CreateMavenJobPom extends AbstractMavenProcessorPom {
     }
 
     private String getCoordinate(Dependency dependency) {
-        return getCoordinate(dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(), dependency.getVersion());
+        return getCoordinate(dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(),
+                dependency.getVersion(), dependency.getClassifier());
     }
 
-    protected String getCoordinate(String groupId, String artifactId, String type, String version) {
+    protected String getCoordinate(String groupId, String artifactId, String type, String version, String classifier) {
         String separator = ":"; //$NON-NLS-1$
         String coordinate = groupId + separator;
         coordinate += artifactId + separator;
@@ -764,7 +784,11 @@ public class CreateMavenJobPom extends AbstractMavenProcessorPom {
         if (version != null) {
             coordinate += separator + version;
         }
-        
+
+        if (StringUtils.isNotBlank(classifier)) {
+            coordinate += separator + classifier;
+        }
+
         return coordinate;
     }
     
@@ -784,20 +808,11 @@ public class CreateMavenJobPom extends AbstractMavenProcessorPom {
         
         return coordinate;
     }
-    
-    protected Dependency getDependencyObject(String groupId, String artifactId, String version, String type, String classifier) {
-        Dependency object = new SortableDependency();
-        object.setGroupId(groupId);
-        object.setArtifactId(artifactId);
-        object.setVersion(version);
-        object.setType(type);
-        object.setClassifier(classifier);
-        
-        return object;
-    }
 
     private void addToDuplicateLibs(Map<String, Set<Dependency>> map, Dependency dependency) {
-        String coordinate = getCoordinate(dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(), null);
+        String coordinate =
+                getCoordinate(dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(), null,
+                        dependency.getClassifier());
         if (!map.containsKey(coordinate)) {
             Set<Dependency> set = new HashSet<>();
             map.put(coordinate, set);

--- a/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/tools/creator/CreateMavenStandardJobOSGiPom.java
+++ b/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/tools/creator/CreateMavenStandardJobOSGiPom.java
@@ -220,9 +220,10 @@ public class CreateMavenStandardJobOSGiPom extends CreateMavenJobPom {
             for (JobInfo jobInfo : childrenJobInfo) {
                 Property property = jobInfo.getProcessItem().getProperty();
                 String coordinate = getCoordinate(PomIdsHelper.getJobGroupId(property), PomIdsHelper.getJobArtifactId(jobInfo),
-                        MavenConstants.PACKAGING_JAR, PomIdsHelper.getJobVersion(property));
-                Dependency dependency = getDependencyObject(PomIdsHelper.getJobGroupId(property), PomIdsHelper.getJobArtifactId(jobInfo), PomIdsHelper.getJobVersion(property),
-                                MavenConstants.PACKAGING_JAR, null);
+                        MavenConstants.PACKAGING_JAR, PomIdsHelper.getJobVersion(property), null);
+                Dependency dependency = PomUtil.createDependency(PomIdsHelper.getJobGroupId(property),
+                        PomIdsHelper.getJobArtifactId(jobInfo), PomIdsHelper.getJobVersion(property),
+                        MavenConstants.PACKAGING_JAR);
                 jobCoordinateMap.put(coordinate, dependency);
             }
         }
@@ -230,9 +231,10 @@ public class CreateMavenStandardJobOSGiPom extends CreateMavenJobPom {
         Property parentProperty = this.getJobProcessor().getProperty();
         String parentCoordinate = getCoordinate(PomIdsHelper.getJobGroupId(parentProperty),
                 PomIdsHelper.getJobArtifactId(parentProperty), MavenConstants.PACKAGING_JAR,
-                PomIdsHelper.getJobVersion(parentProperty));
-        Dependency parentDependency = getDependencyObject(PomIdsHelper.getJobGroupId(parentProperty), PomIdsHelper.getJobArtifactId(parentProperty), PomIdsHelper.getJobVersion(parentProperty),
-                        MavenConstants.PACKAGING_JAR, null);
+                PomIdsHelper.getJobVersion(parentProperty), null);
+        Dependency parentDependency = PomUtil.createDependency(PomIdsHelper.getJobGroupId(parentProperty),
+                PomIdsHelper.getJobArtifactId(parentProperty), PomIdsHelper.getJobVersion(parentProperty),
+                MavenConstants.PACKAGING_JAR);
         jobCoordinateMap.put(parentCoordinate, parentDependency);
         try {
             Document document = PomUtil.loadAssemblyFile(null, assemblyFile);

--- a/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/PomUtil.java
+++ b/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/PomUtil.java
@@ -27,6 +27,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -79,6 +80,7 @@ import org.talend.core.model.process.JobInfo;
 import org.talend.core.model.process.ProcessUtils;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.core.model.properties.Property;
+import org.talend.core.model.repository.ERepositoryObjectType;
 import org.talend.core.model.utils.JavaResourcesHelper;
 import org.talend.core.nexus.TalendMavenResolver;
 import org.talend.core.runtime.maven.MavenArtifact;
@@ -91,6 +93,7 @@ import org.talend.designer.maven.model.TalendMavenConstants;
 import org.talend.designer.maven.template.MavenTemplateManager;
 import org.talend.designer.maven.tools.ProcessorDependenciesManager;
 import org.talend.designer.runprocess.IProcessor;
+import org.talend.designer.runprocess.IRunProcessService;
 import org.talend.repository.ProjectManager;
 import org.w3c.dom.Attr;
 import org.w3c.dom.DOMImplementation;
@@ -1037,5 +1040,19 @@ public class PomUtil {
             }
         }
         return found;
+    }
+
+    public static Set<Dependency> getCodesDependencies(ERepositoryObjectType codeType) throws CoreException {
+        Set<Dependency> dependencies = new HashSet<Dependency>();
+
+        if (GlobalServiceRegister.getDefault().isServiceRegistered(IRunProcessService.class)) {
+            IRunProcessService runProcessService = (IRunProcessService) GlobalServiceRegister.getDefault()
+                    .getService(IRunProcessService.class);
+            ITalendProcessJavaProject talendCodeJavaProject = runProcessService.getTalendCodeJavaProject(codeType);
+            IFile projectPom = talendCodeJavaProject.getProjectPom();
+            Model model = MODEL_MANAGER.readMavenModel(projectPom);
+            dependencies.addAll(model.getDependencies());
+        }
+        return dependencies;
     }
 }

--- a/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/SortableDependency.java
+++ b/main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/SortableDependency.java
@@ -10,4 +10,37 @@ public class SortableDependency extends Dependency implements Comparable<Sortabl
         return getArtifactId().compareTo(o.getArtifactId());
     }
 
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + (getGroupId() == null ? 0 : getGroupId().hashCode());
+        result = 31 * result + (getArtifactId() == null ? 0 : getArtifactId().hashCode());
+        result = 31 * result + (getVersion() == null ? 0 : getVersion().hashCode());
+        result = 31 * result + (getType() == null ? 0 : getType().hashCode());
+        result = 31 * result + (getClassifier() == null ? 0 : getClassifier().hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof SortableDependency)) {
+            return false;
+        }
+        SortableDependency caseobj = (SortableDependency) obj;
+
+        return (getGroupId() == caseobj.getGroupId() || (getGroupId() != null && getGroupId().equals(caseobj.getGroupId())))
+                && (getArtifactId() == caseobj.getArtifactId()
+                        || (getArtifactId() != null && getArtifactId().equals(caseobj.getArtifactId())))
+                && (getVersion() == caseobj.getVersion() || (getVersion() != null && getVersion().equals(caseobj.getVersion())))
+                && (getType() == caseobj.getType() || (getType() != null && getType().equals(caseobj.getType())))
+                && (getClassifier() == caseobj.getClassifier()
+                        || (getClassifier() != null && getClassifier().equals(caseobj.getClassifier())));
+    }
+
 }

--- a/test/plugins/org.talend.designer.maven.test/src/main/java/org/talend/designer/maven/utils/SortableDependencyTest.java
+++ b/test/plugins/org.talend.designer.maven.test/src/main/java/org/talend/designer/maven/utils/SortableDependencyTest.java
@@ -1,0 +1,49 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.designer.maven.utils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * DOC jding class global comment. Detailled comment
+ */
+public class SortableDependencyTest {
+
+    @Test
+    public void testEqualsHashcode() {
+        SortableDependency dependency = new SortableDependency();
+        dependency.setGroupId("org.example.test");
+        dependency.setArtifactId("test");
+        SortableDependency dependency1 = new SortableDependency();
+        dependency1.setGroupId("org.example.test");
+        dependency1.setArtifactId("test");
+
+        Set<SortableDependency> dependencySet = new HashSet<SortableDependency>();
+        dependencySet.add(dependency);
+        dependencySet.add(dependency1);
+        Assert.assertEquals(1, dependencySet.size());
+        Assert.assertTrue(dependency.equals(dependency1));
+
+        dependency.setVersion("0.1");
+        dependency1.setVersion("0.2");
+        dependencySet.add(dependency1);
+        Assert.assertEquals(2, dependencySet.size());
+        Assert.assertFalse(dependency.equals(dependency1));
+
+    }
+
+}


### PR DESCRIPTION
* fix(TUP-26165)jar referenced in bat or sh classpath missing in build
ZIP (#3105)

* fix(TUP-26165)jar referenced in bat or sh classpath missing in build
ZIP
file folder lib
https://jira.talendforge.org/browse/TUP-26165

* fix(TUP-26165)jar referenced in bat or sh classpath missing in build
ZIP
file folder lib
https://jira.talendforge.org/browse/TUP-26165

* fix(TUP-26165)jar referenced in bat or sh classpath missing in build
ZIP
file folder lib
https://jira.talendforge.org/browse/TUP-26165

* fix(TUP-26165)jar referenced in bat or sh classpath missing in build
ZIP
file folder lib
https://jira.talendforge.org/browse/TUP-26165

* fix(TUP-26165)jar referenced in bat or sh classpath missing in build
ZIP
file folder lib
https://jira.talendforge.org/browse/TUP-26165

* fix(TUP-26165):fix jar with classifier missing issue

Co-authored-by: Jane Ding <35018295+jding-tlnd@users.noreply.github.com>

Conflicts:
	main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/tools/creator/CreateMavenJobPom.java
	main/plugins/org.talend.designer.maven/src/main/java/org/talend/designer/maven/utils/PomUtil.java