### PR TITLE
TESB-28895 Route node is missing in project setting

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/repository/ERepositoryObjectType.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/model/repository/ERepositoryObjectType.java
@@ -532,6 +532,11 @@ public class ERepositoryObjectType extends DynaEnum<ERepositoryObjectType> {
     /**
      * <font color="red">This value may be <b>null</b> in some licenses, <b>should add NPE check</b></font>
      */
+    public final static ERepositoryObjectType PROCESS_ROUTE_DESIGN = ERepositoryObjectType.valueOf("ROUTE_DESIGNS");
+
+    /**
+     * <font color="red">This value may be <b>null</b> in some licenses, <b>should add NPE check</b></font>
+     */
     public final static ERepositoryObjectType PROCESS_ROUTE_MICROSERVICE = ERepositoryObjectType.valueOf("ROUTE_MICROSERVICE"); //$NON-NLS-1$
 
     /**

--- a/main/plugins/org.talend.designer.maven.ui/src/main/java/org/talend/designer/maven/ui/setting/repository/tester/AbstractRepositoryNodeRepositorySettingTester.java
+++ b/main/plugins/org.talend.designer.maven.ui/src/main/java/org/talend/designer/maven/ui/setting/repository/tester/AbstractRepositoryNodeRepositorySettingTester.java
@@ -33,6 +33,9 @@ public abstract class AbstractRepositoryNodeRepositorySettingTester implements I
                 if (contentType.equals(getType())) {
                     return true;
                 }
+                if (contentType.equals(ERepositoryObjectType.PROCESS_ROUTE_DESIGN)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
The reason of this bug is that Routes are inside Route Designs folder, so we also need to display Route Designs in settings.
![maven](https://user-images.githubusercontent.com/53863455/80064951-e932a400-8541-11ea-8dee-00a006c7fa99.png)
