### PR TITLE
fix(TDI-44093): Add method that checks if string wrapped by quotes

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/utils/TalendQuoteUtils.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/utils/TalendQuoteUtils.java
@@ -281,6 +281,20 @@ public final class TalendQuoteUtils {
         return text;
     }
 
+    public static boolean checkTextQuotation(String text) {
+        if (text == null || text.length() == 0) {
+            return false;
+        } else {
+            String begin = text.substring(0, 1);
+            String end = text.substring(text.length() - 1, text.length());
+            if (QUOTATION_MARK.equals(begin) && QUOTATION_MARK.equals(end)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
     /**
      *
      * ggu Comment method "addQuotesForSQLString".

--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/utils/TalendQuoteUtils.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/utils/TalendQuoteUtils.java
@@ -281,18 +281,15 @@ public final class TalendQuoteUtils {
         return text;
     }
 
-    public static boolean checkTextQuotation(String text) {
-        if (text == null || text.length() == 0) {
+    public static boolean isEnclosed(String text) {
+        if (text == null) {
             return false;
-        } else {
-            String begin = text.substring(0, 1);
-            String end = text.substring(text.length() - 1, text.length());
-            if (QUOTATION_MARK.equals(begin) && QUOTATION_MARK.equals(end)) {
-                return true;
-            } else {
-                return false;
-            }
         }
+        text = text.trim();
+        if (text.isEmpty()) {
+            return false;
+        }
+        return text.startsWith(QUOTATION_MARK) && text.endsWith(QUOTATION_MARK);
     }
 
     /**

--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/utils/TalendQuoteUtils.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/utils/TalendQuoteUtils.java
@@ -286,7 +286,7 @@ public final class TalendQuoteUtils {
             return false;
         }
         text = text.trim();
-        if (text.isEmpty()) {
+        if (text.length() < 2) {
             return false;
         }
         return text.startsWith(QUOTATION_MARK) && text.endsWith(QUOTATION_MARK);

--- a/main/plugins/org.talend.core/src/main/java/org/talend/core/model/utils/TalendTextUtils.java
+++ b/main/plugins/org.talend.core/src/main/java/org/talend/core/model/utils/TalendTextUtils.java
@@ -477,8 +477,8 @@ public class TalendTextUtils {
         return TalendQuoteUtils.removeQuotes(text, quotation);
     }
 
-    public static boolean checkTextQuotation(String text) {
-        return TalendQuoteUtils.checkTextQuotation(text);
+    public static boolean isEnclosed(String text) {
+        return TalendQuoteUtils.isEnclosed(text);
     }
 
     public static String getStringConnect() {

--- a/main/plugins/org.talend.core/src/main/java/org/talend/core/model/utils/TalendTextUtils.java
+++ b/main/plugins/org.talend.core/src/main/java/org/talend/core/model/utils/TalendTextUtils.java
@@ -477,6 +477,10 @@ public class TalendTextUtils {
         return TalendQuoteUtils.removeQuotes(text, quotation);
     }
 
+    public static boolean checkTextQuotation(String text) {
+        return TalendQuoteUtils.checkTextQuotation(text);
+    }
+
     public static String getStringConnect() {
         return TalendQuoteUtils.getStringConnect();
     }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-44093
Syntax error when use query for tCosmosDBSQLAPIInput. Logic remove and add quotes by default.

**What is the new behavior?**
Currently strings with quoted values process as expected.
New method check is it necessary quote string