### PR TITLE
bugfix(TUP-27062):String Datatype Created by Guess Schema When Accessing

### DIFF
--- a/main/plugins/org.talend.core.runtime/mappings/mapping_Impala.xml
+++ b/main/plugins/org.talend.core.runtime/mappings/mapping_Impala.xml
@@ -78,7 +78,6 @@
 				<dbType type="DOUBLE">
 					<talendType type="id_Double" default="true"/>
 					<talendType type="id_BigDecimal"/>
-					<talendType type="id_Float"/>
 				</dbType>
 				<dbType type="BIGINT">
 					<talendType type="id_BigDecimal" default="true"/>


### PR DESCRIPTION
an Impala Double Field