### PR TITLE
chore(TUP-27463):Backport TUP-26304 to 7.3:Re-use

### DIFF
--- a/main/plugins/org.talend.designer.maven.tos/resources/components/pom.xml
+++ b/main/plugins/org.talend.designer.maven.tos/resources/components/pom.xml
@@ -9,9 +9,6 @@
     </parent>
 	<artifactId>studio-components-dependencies</artifactId>
 	<packaging>pom</packaging>
-	<properties>
-		<components.version>0.28.5</components.version>
-	</properties>
 	<repositories>
 		<repository>
 			<id>talend_open</id>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,6 @@
 	</parent>
 	<artifactId>tcommon-studio-se</artifactId>
 	<packaging>pom</packaging>
-	<properties>
-		<org.talend.daikon.crypto-utils.version>0.31.10</org.talend.daikon.crypto-utils.version>
-	</properties>
 	<repositories>
 		<repository>
 			<id>talend_open</id>


### PR DESCRIPTION
talend.studio.parent.pom as a root studio bom for SE/EE product