### PR TITLE
Fix/yyin/tdq 18565 context check 73 (#3462)

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/ITDQRepositoryService.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/ITDQRepositoryService.java
@@ -214,5 +214,5 @@ public interface ITDQRepositoryService extends IService {
     /**
      * @param chooseContext the context name which want to swtich
      */
-    void popupSwitchContextFailedMessage(String chooseContext);
+    boolean popupSwitchContextFailedMessage(String chooseContext);
 }

--- a/main/plugins/org.talend.repository.metadata/src/main/java/org/talend/repository/ui/wizards/metadata/connection/database/DatabaseWizard.java
+++ b/main/plugins/org.talend.repository.metadata/src/main/java/org/talend/repository/ui/wizards/metadata/connection/database/DatabaseWizard.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.EMap;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.window.Window;
@@ -560,8 +561,8 @@ public class DatabaseWizard extends CheckLastVersionRepositoryWizard implements 
                         isSuccess = SwitchContextGroupNameImpl
                                 .getInstance()
                                 .updateContextGroup(connectionItem, contextName, originalSelectedContextType.getName());
-                        if (!isSuccess) {
-                            tdqRepService.popupSwitchContextFailedMessage(contextName);
+                         if (!isSuccess) {
+                        	isSuccess = tdqRepService.popupSwitchContextFailedMessage(contextName);
                         }else {
                             isSuccess &= handleDatabaseUpdate(metadataConnection, tdqRepService);
                         }


### PR DESCRIPTION
* Fix TDQ-18565  Cannot save Hive metadata object with context variables

- if the analysis didnot use the current db, can pass
- if any analysis use this db, popup let the user select

* FIx TDQ-18565

* Fix TDQ-18565 backport to 73

Co-authored-by: root <root@LT-D9QV733>