### PR TITLE
TPSVC-15154 - allow debug logs for deletions to see which files are purged

### DIFF
--- a/main/plugins/org.talend.utils/src/main/java/org/talend/utils/files/FileDirCleaner.java
+++ b/main/plugins/org.talend.utils/src/main/java/org/talend/utils/files/FileDirCleaner.java
@@ -297,6 +297,9 @@ public class FileDirCleaner {
                                 if (checkFilter(fileDirJob)) {
                                     if (doAction) {
                                         org.apache.commons.io.FileUtils.deleteDirectory(fileDirJob);
+                                        if (log.isDebugEnabled()) {
+                                            log.debug("Deleted directory: " + fileDirJob);
+                                        }
                                     } else {
                                         StringBuilder reason = new StringBuilder();
                                         String sep = "";
@@ -321,6 +324,9 @@ public class FileDirCleaner {
                                 if (checkFilter(fileDirJob)) {
                                     if (doAction) {
                                         org.apache.commons.io.FileUtils.forceDelete(fileDirJob);
+                                        if (log.isDebugEnabled()) {
+                                            log.debug("Deleted file: " + fileDirJob);
+                                        }
                                     } else {
                                         StringBuilder reason = new StringBuilder();
                                         String sep = "";


### PR DESCRIPTION
We have a number of cases with FileNotFoundException's on the jobserver cache standalone / in RE where these logs would help to understand what happened when.