### PR TITLE
feat(TCOMP-1651): bump component-runtime to 1.1.24

### DIFF
--- a/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
+++ b/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
     
     <properties>
-        <tcomp.version>1.1.15.2</tcomp.version>
+        <tcomp.version>1.1.24</tcomp.version>
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
     


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Dynamic Columns handling in Studio:
https://jira.talendforge.org/browse/TCOMP-1651

**Related PRs:**
- https://github.com/Talend/studio-full-master/pull/423
- https://github.com/Talend/tdi-studio-ee/pull/1362
- https://github.com/Talend/tdi-studio-se/pull/4861
- https://github.com/Talend/tcommon-studio-se/pull/3620
- https://github.com/Talend/tcommon-studio-ee/pull/1506
