### PR TITLE
fix(TCOMP-1770): bump component-runtime to 1.1.25

### DIFF
--- a/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
+++ b/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
     
     <properties>
-        <tcomp.version>1.1.24</tcomp.version>
+        <tcomp.version>1.1.25</tcomp.version>
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
     


### PR DESCRIPTION
https://jira.talendforge.org/browse/TCOMP-1770
https://jira.talendforge.org/browse/TDI-44874

**Related PR**
- https://github.com/Talend/studio-full-master/pull/439
- https://github.com/Talend/tcommon-studio-ee/pull/1522
- https://github.com/Talend/tcommon-studio-se/pull/3637
- https://github.com/Talend/tdi-studio-se/pull/5201
