### PR TITLE
TESB-31287:

### DIFF
--- a/main/plugins/org.talend.commons.runtime/talend.properties
+++ b/main/plugins/org.talend.commons.runtime/talend.properties
@@ -1,1 +1,1 @@
-talend.version=7.4.1
+talend.version=7.4.1-SNAPSHOT


### PR DESCRIPTION
talend.version value is wrong in talend.properties in org.talend.commons.runtime_7.4.1.xxxxx.jar