### PR TITLE
fix(TUP-29344):Local context variables of new context envs inherited …

### DIFF
--- a/main/plugins/org.talend.metadata.managment.ui/src/main/java/org/talend/metadata/managment/ui/utils/ConnectionContextHelper.java
+++ b/main/plugins/org.talend.metadata.managment.ui/src/main/java/org/talend/metadata/managment/ui/utils/ConnectionContextHelper.java
@@ -703,7 +703,7 @@ public final class ConnectionContextHelper {
                     Set<String> addedVars = tempVars;
 
                     if (addedVars != null && !addedVars.isEmpty()
-                            && (isGeneric || !isAddContextVar(contextItem, process.getContextManager(), neededVars))) {
+                            && (isGeneric || !isAddContextVar(contextItem, process.getContextManager(), neededVars, true))) {
                         AtomicBoolean added = new AtomicBoolean();
                         if (ignoreContextMode) {
                             addContextVarForJob(process, contextItem, addedVars);
@@ -1591,7 +1591,13 @@ public final class ConnectionContextHelper {
     }
 
     public static boolean isAddContextVar(ContextItem contextItem, IContextManager contextManager, Set<String> neededVars) {
+        return isAddContextVar(contextItem, contextManager, neededVars, false);
+    }
+
+    public static boolean isAddContextVar(ContextItem contextItem, IContextManager contextManager, Set<String> neededVars,
+            boolean checkByDefault) {
         boolean isAdd = true;
+        boolean foundGroup = false;
         Set<String> addedVars = new HashSet<String>();
         for (IContext context : contextManager.getListContext()) {
             ContextType contextType = null;
@@ -1599,6 +1605,7 @@ public final class ConnectionContextHelper {
             for (ContextType contye : contextTypeList) {
                 if (context.getName() != null && contye.getName().equalsIgnoreCase(context.getName())) {
                     contextType = contye;
+                    foundGroup = true;
                     break;
                 }
             }
@@ -1615,6 +1622,26 @@ public final class ConnectionContextHelper {
                 break;
             }
         }
+
+        // if not found might different groups, check from default context if duplicate var
+        if (checkByDefault && !foundGroup) {
+            IContext jobDefaultContext = contextManager.getDefaultContext();
+            String itemDefaultContextName = contextItem.getDefaultContext();
+            List<ContextType> contextTypeList = contextItem.getContext();
+            ContextType itemDefaultContext = ContextUtils.getContextTypeByName(contextTypeList, itemDefaultContextName);
+            if (itemDefaultContext != null) {
+                for (String var : neededVars) {
+                    if (jobDefaultContext.getContextParameter(var) != null) {
+                        continue;
+                    }
+                    ContextParameterType param = ContextUtils.getContextParameterTypeByName(itemDefaultContext, var);
+                    if (param != null) {
+                        addedVars.add(var);
+                    }
+                }
+            }
+        }
+
         if (addedVars != null && !addedVars.isEmpty()) {
             isAdd = false;
         }

--- a/test/plugins/org.talend.metadata.managment.ui.test/src/main/test/org/talend/metadata/managment/ui/utils/ConnectionContextHelperTest.java
+++ b/test/plugins/org.talend.metadata.managment.ui.test/src/main/test/org/talend/metadata/managment/ui/utils/ConnectionContextHelperTest.java
@@ -16,11 +16,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
+import org.junit.Assert;
 import org.junit.Test;
 import org.talend.core.model.context.JobContextManager;
 import org.talend.core.model.context.JobContextParameter;
@@ -31,6 +33,7 @@ import org.talend.core.model.process.IContextParameter;
 import org.talend.core.model.properties.ContextItem;
 import org.talend.core.model.properties.PropertiesFactory;
 import org.talend.core.model.properties.Property;
+import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.designer.core.model.utils.emf.talendfile.ContextParameterType;
 import org.talend.designer.core.model.utils.emf.talendfile.ContextType;
 import org.talend.designer.core.model.utils.emf.talendfile.TalendFileFactory;
@@ -104,6 +107,52 @@ public class ConnectionContextHelperTest {
         Set<String> set = ConnectionContextHelper.checkAndAddContextVariables(contextItem, contextManager, false,
                 new HashMap<String, String>());
         assertTrue(set.size() == 2);
+    }
+
+    @Test
+    public void testIsAddedContextVar() {
+        JobContextManager contextManager = new JobContextManager();
+        List<IContextParameter> contextParameterList = contextManager.getDefaultContext().getContextParameterList();
+        IContextParameter contextParam = new JobContextParameter();
+        contextParam.setName("new1");
+        contextParam.setType(JavaTypesManager.getDefaultJavaType().getId());
+        contextParameterList.add(contextParam);
+
+        EList contextTypeList = new BasicEList();
+        ContextType contextType = TalendFileFactory.eINSTANCE.createContextType();
+        contextType.setName("dev");
+        contextTypeList.add(contextType);
+        ContextParameterType contextParameterType = TalendFileFactory.eINSTANCE.createContextParameterType();
+        contextParameterType.setName("new1");
+        contextParameterType.setType(JavaTypesManager.getDefaultJavaType().getId());
+        contextType.getContextParameter().add(contextParameterType);
+        contextParameterType = TalendFileFactory.eINSTANCE.createContextParameterType();
+        contextParameterType.setName("new2");
+        contextParameterType.setType(JavaTypesManager.getDefaultJavaType().getId());
+        contextType.getContextParameter().add(contextParameterType);
+
+        ContextItem contextItem = PropertiesFactory.eINSTANCE.createContextItem();
+        contextItem.getContext().add(contextType);
+        Property myContextProperty = PropertiesFactory.eINSTANCE.createProperty();
+        myContextProperty.setId(ProxyRepositoryFactory.getInstance().getNextId());
+        myContextProperty.setLabel("testContext");
+        myContextProperty.setVersion("0.1");
+        contextItem.setProperty(myContextProperty);
+        contextItem.setDefaultContext("dev");
+
+        Set<String> neededVars = new HashSet<String>();
+        neededVars.add("new1");
+        boolean result = ConnectionContextHelper.isAddContextVar(contextItem, contextManager, neededVars, false);
+        Assert.assertTrue(result);
+        result = ConnectionContextHelper.isAddContextVar(contextItem, contextManager, neededVars, true);
+        Assert.assertTrue(result);
+
+        neededVars.add("new2");
+        result = ConnectionContextHelper.isAddContextVar(contextItem, contextManager, neededVars, false);
+        Assert.assertTrue(result);
+        result = ConnectionContextHelper.isAddContextVar(contextItem, contextManager, neededVars, true);
+        Assert.assertFalse(result);
+
     }
 
 }


### PR DESCRIPTION
…(#3880)

* fix(TUP-29344):Local context variables of new context envs inherited
from Metadata Connection are read-only
https://jira.talendforge.org/browse/TUP-29344

Signed-off-by: jding-tlnd <jding@talend.com>

* fix(TUP-29344):Local context variables of new context envs inherited
from Metadata Connection are read-only
https://jira.talendforge.org/browse/TUP-29344

Signed-off-by: jding-tlnd <jding@talend.com>