### PR TITLE
Fix TUP-29744 The parameter value of jobType is wrong for new created testcase. (Remove unuseful migration task)

### DIFF
--- a/main/plugins/org.talend.core/src/main/java/org/talend/core/model/migration/AbstractJobMigrationTask.java
+++ b/main/plugins/org.talend.core/src/main/java/org/talend/core/model/migration/AbstractJobMigrationTask.java
@@ -48,12 +48,20 @@ public abstract class AbstractJobMigrationTask extends AbstractItemMigrationTask
         if (processType != null) {
             EmfHelper.visitChilds(processType);
             ERepositoryObjectType itemType = ERepositoryObjectType.getItemType(item);
-            if(itemType == ERepositoryObjectType.TEST_CONTAINER &&
-            		!ConvertJobsUtil.JobType.STANDARD.getDisplayName().equalsIgnoreCase(processType.getJobType())){
-            	return null;
+            if (itemType == ERepositoryObjectType.TEST_CONTAINER
+                    && !ConvertJobsUtil.JobType.STANDARD.getDisplayName()
+                            .equalsIgnoreCase(getTestContainerJobType(item, processType))) {
+                return null;
             }
 
         }
         return processType;
+    }
+
+    protected String getTestContainerJobType(Item item, ProcessType processType) {
+        if (item.getState() != null && item.getState().getPath() != null) {
+            return ConvertJobsUtil.getTestCaseJobTypeByPath(item.getState().getPath());
+        }
+        return processType.getJobType();
     }
 }


### PR DESCRIPTION
Fix TUP-29744 The parameter value of jobType is wrong for new created testcase. (Remove unuseful migration task)
https://jira.talendforge.org/browse/TUP-29744