### PR TITLE
TUP-34420 In 8.0 patch, there are some libraries plugin's version can't

### DIFF
--- a/main/plugins/org.talend.libraries.apache/pom.xml
+++ b/main/plugins/org.talend.libraries.apache/pom.xml
@@ -13,6 +13,7 @@
 		<log4j.version>1.2.17</log4j.version>
 		<slf4j.version>1.7.29</slf4j.version>
 		<log4j2.version>2.17.1</log4j2.version>
+		<tycho.buildtimestamp.format>${timestamp}</tycho.buildtimestamp.format>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/main/plugins/org.talend.libraries.persist.lookup/pom.xml
+++ b/main/plugins/org.talend.libraries.persist.lookup/pom.xml
@@ -9,4 +9,7 @@
   </parent>
   <artifactId>org.talend.libraries.persist.lookup</artifactId>
   <packaging>eclipse-plugin</packaging>
+    <properties>
+		<tycho.buildtimestamp.format>${timestamp}</tycho.buildtimestamp.format>
+	</properties>
 </project>


### PR DESCRIPTION
TUP-34420 In 8.0 patch, there are some libraries plugin's version can't update that cause Studio can't apply it.
https://jira.talendforge.org/browse/TUP-34420