### PR TITLE
feat(TDI-48418): Bump component-runtime to 1.48

### DIFF
--- a/main/plugins/org.talend.designer.maven.repo.tcksdk/pom.xml
+++ b/main/plugins/org.talend.designer.maven.repo.tcksdk/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>eclipse-plugin</packaging>
 	<properties>
 		<tcomp.version>${component-runtime.version}</tcomp.version>
-		<cxf.version>3.5.1</cxf.version>
+		<cxf.version>3.5.2</cxf.version>
 		<geronimo.version>1.0.2</geronimo.version>
 		<jcache.version>1.0.5</jcache.version>
 		<jcache_spec.version>1.0-alpha-1</jcache_spec.version>
@@ -20,7 +20,7 @@
 		<microprofile.version>1.2.1</microprofile.version>
 		<owb.version>2.0.26</owb.version>
 		<slf4j.version>1.7.33</slf4j.version>
-		<tomcat.version>9.0.62</tomcat.version>
+		<tomcat.version>9.0.63</tomcat.version>
 		<xbean.version>4.20</xbean.version>
 		<reload4j.version>1.2.19</reload4j.version>
 		<log4j2.version>2.17.2</log4j2.version>

--- a/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
+++ b/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tcomp.version>1.47.1</tcomp.version>
+        <tcomp.version>1.48.1</tcomp.version>
         <slf4j.version>1.7.32</slf4j.version>
         <reload4j.version>1.2.19</reload4j.version>
     </properties>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-48418

This includes the following fixes:
- fix(TCOMP-2182): pass version to tck guess schema

***Related PR***

**master**
- https://github.com/Talend/studio-se-master/pull/679
- https://github.com/Talend/tcommon-studio-se/pull/5592
- https://github.com/Talend/tdi-studio-se/pull/7987

**maintenance/8.0**
- https://github.com/Talend/studio-se-master/pull/681
- https://github.com/Talend/tcommon-studio-se/pull/5593
- https://github.com/Talend/tdi-studio-se/pull/7988
