### PR TITLE
TUP-38645 On dark mode, Job designer & subjob color can't restore to

### DIFF
--- a/main/plugins/org.talend.themes.css.talend/themes/dark/dark/e4-dark_preferencestyle.css
+++ b/main/plugins/org.talend.themes.css.talend/themes/dark/dark/e4-dark_preferencestyle.css
@@ -18,9 +18,6 @@
 
 IEclipsePreferences#org-talend-designer-core:org-talend-themes-css-talend-base { /* pseudo attribute added to allow contributions without replacing this node, see Bug 466075 */
 	preferences:
-		'jobDesignerBackgroundColor=122,122,122'
-		'subjobColor=70,70,70'
-		'subjobTitleColor=102,191,230'
 		'forbiddenSubjobColor=207,226,236'
 		'forbiddenSubjobTitleColor=92,131,150'
 }
@@ -137,6 +134,13 @@ IEclipsePreferences#org-eclipse-ui-workbench:org-talend-themes-css-talend-base {
 		'operatorColor=178,34,0'
 		'digitColor=160,32,0'
 		'invalidColor=178,0,34'
+		
+		/*Designer color preference page default color */
+		'jobDesignerBackgroundColor=122,122,122'
+		'subjobColor=70,70,70'
+		'subjobTitleColor=102,191,230'
+		'jobletColor=76,73,228'
+		'readOnlyBackgroundColor=231,231,231'
 		
 		/*GEF Job Editor*/
 		'NODE_FIGURE_LABEL_FORCEGROUND=255,255,255'

--- a/main/plugins/org.talend.themes.css.talend/themes/default/css/preferencestyle.css
+++ b/main/plugins/org.talend.themes.css.talend/themes/default/css/preferencestyle.css
@@ -18,9 +18,6 @@
 
 IEclipsePreferences#org-talend-designer-core:org-talend-themes-css-talend-base { /* pseudo attribute added to allow contributions without replacing this node, see Bug 466075 */
 	preferences:
-		'jobDesignerBackgroundColor=250,250,250'
-		'subjobColor=207,226,236'
-		'subjobTitleColor=92,131,150'
 		'forbiddenSubjobColor=70,70,70'
 		'forbiddenSubjobTitleColor=102,191,230'
 }
@@ -75,6 +72,13 @@ IEclipsePreferences#org-eclipse-ui-workbench:org-talend-themes-css-talend-base {
 		'operatorColor=178,34,0'
 		'digitColor=160,32,0'
 		'invalidColor=178,0,34'
+		
+		/*Designer color preference page default color */
+		'jobDesignerBackgroundColor=250,250,250'
+		'subjobColor=207,226,236'
+		'subjobTitleColor=92,131,150'
+		'jobletColor=130,240,100'
+		'readOnlyBackgroundColor=231,231,231'
 }
 
 


### PR DESCRIPTION
TUP-38645 On dark mode, Job designer & subjob color can't restore to correct default color
https://jira.talendforge.org/browse/TUP-38645