### PR TITLE
feat(TDI-49951): bump component-runtime to 1.58

### DIFF
--- a/main/plugins/org.talend.designer.maven.repo.tcksdk/pom.xml
+++ b/main/plugins/org.talend.designer.maven.repo.tcksdk/pom.xml
@@ -15,12 +15,12 @@
 		<geronimo.version>1.0.2</geronimo.version>
 		<jcache.version>1.0.5</jcache.version>
 		<jcache_spec.version>1.0-alpha-1</jcache_spec.version>
-		<johnzon.version>1.2.19</johnzon.version>
+		<johnzon.version>1.2.20</johnzon.version>
 		<meecrowave.version>1.2.15</meecrowave.version>
 		<microprofile.version>1.2.1</microprofile.version>
 		<owb.version>2.0.27</owb.version>
 		<slf4j.version>1.7.34</slf4j.version>
-		<tomcat.version>9.0.73</tomcat.version>
+		<tomcat.version>9.0.75</tomcat.version>
 		<xbean.version>4.20</xbean.version>
 		<reload4j.version>1.2.22</reload4j.version>
 		<log4j2.version>2.20.0</log4j2.version>

--- a/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
+++ b/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tcomp.version>1.58.0</tcomp.version>
+        <tcomp.version>1.59.0-SNAPSHOT</tcomp.version>
         <slf4j.version>1.7.34</slf4j.version>
         <reload4j.version>1.2.22</reload4j.version>
     </properties>

--- a/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
+++ b/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tcomp.version>1.59.0-SNAPSHOT</tcomp.version>
+        <tcomp.version>1.58.0</tcomp.version>
         <slf4j.version>1.7.34</slf4j.version>
         <reload4j.version>1.2.22</reload4j.version>
     </properties>

--- a/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
+++ b/main/plugins/org.talend.designer.maven.tos/resources/tcompv1/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tcomp.version>1.57.1</tcomp.version>
+        <tcomp.version>1.58.0</tcomp.version>
         <slf4j.version>1.7.34</slf4j.version>
         <reload4j.version>1.2.22</reload4j.version>
     </properties>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-49951

*Related PR*
- https://github.com/Talend/studio-se-master/pull/819
- https://github.com/Talend/tcommon-studio-se/pull/6250
- https://github.com/Talend/studio-se-master/pull/820 (maintenance/8.0)
- https://github.com/Talend/tcommon-studio-se/pull/6251 (maintenance/8.0)

included tdi-studio-se features:
[x] feat(TCOMP-2443): allow component-server extensions for Studio

- https://github.com/Talend/tdi-studio-se/pull/8892
- https://github.com/Talend/tdi-studio-se/pull/8891 (maintenance/8.0)
