### PR TITLE
fix(TUP-41020): LDAP Metadata : Check Authentication fails when Encryption method = LDAPS(SSL) even with correct credentials.

### DIFF
--- a/main/plugins/org.talend.core.repository/src/main/java/org/talend/core/repository/model/ldap/LDAPCATruster.java
+++ b/main/plugins/org.talend.core.repository/src/main/java/org/talend/core/repository/model/ldap/LDAPCATruster.java
@@ -147,7 +147,11 @@ public class LDAPCATruster implements X509TrustManager {
             } catch (IOException ex) {
             }
         try {
-            ks.load(in, certStorePwd);
+            if (in != null) {
+                ks.load(in, certStorePwd);
+            } else {
+                ks = null;
+            }
         } catch (Exception e) {
             log.error(Messages.getString("LDAPCATruster.failedLoadCert") + e.getMessage()); //$NON-NLS-1$
             return;

--- a/test/plugins/org.talend.core.repository.test/src/org/talend/core/repository/model/ldap/LDAPCATrusterTest.java
+++ b/test/plugins/org.talend.core.repository.test/src/org/talend/core/repository/model/ldap/LDAPCATrusterTest.java
@@ -1,0 +1,34 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2023 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.core.repository.model.ldap;
+
+import java.security.cert.X509Certificate;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author PCW created on Nov 28, 2023
+ *
+ */
+public class LDAPCATrusterTest {
+    
+    
+    @Test
+    public void testGetAcceptedIssuers() {
+        LDAPCATruster truster = new LDAPCATruster(null);
+        X509Certificate[] certs = truster.getAcceptedIssuers();
+        Assert.assertTrue(certs.length > 1);
+    }
+
+}


### PR DESCRIPTION
https://jira.talendforge.org/browse/TUP-41020