### PR TITLE
chore(TUP-38828)Ubuntu: Text and background is white in logon dialog

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/designer/core/IDesignerCoreService.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/designer/core/IDesignerCoreService.java
@@ -210,4 +210,5 @@ public interface IDesignerCoreService extends IService {
 
     public List<AnalysisReportRecorder> analysis(Project project) throws PersistenceException;
 
+    public boolean isDarkModeTheme();
 }


### PR DESCRIPTION
when both OS and Studio is in dark mode