### PR TITLE
fix(TUP-41569):Cleaning the HistoryStore during migration helps in

### DIFF
--- a/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/prefs/HistoryStoreHelper.java
+++ b/main/plugins/org.talend.core.runtime/src/main/java/org/talend/core/prefs/HistoryStoreHelper.java
@@ -1,0 +1,82 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2024 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.core.prefs;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+
+import org.eclipse.core.internal.resources.Workspace;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.talend.commons.exception.ExceptionHandler;
+
+/**
+ * DOC OTS  class global comment. Detailled comment
+ */
+public class HistoryStoreHelper {
+
+    private static final HistoryStoreHelper instance = new HistoryStoreHelper();
+
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    private FutureTask<String> cleanTask;
+
+    // for performance, clean in every 10 times for item import and migration
+    private int delayCount = 0;
+
+    private HistoryStoreHelper() {
+    }
+
+    public static HistoryStoreHelper getInstance() {
+        return instance;
+    }
+
+    public void checkAndClean() {
+        checkAndClean(true);
+    }
+
+    public void checkAndClean(boolean delay) {
+        delayCount++;
+        if ((delay && delayCount % 10 != 0) || isCleanTaskRunning()) {
+            return;
+        }
+
+        try {
+            cleanTask = new FutureTask<String>(() -> {
+                try {
+                    IWorkspace workspace = ResourcesPlugin.getWorkspace();
+                    if (workspace instanceof Workspace) {
+                        ((Workspace) workspace).getFileSystemManager().getHistoryStore().clean(new NullProgressMonitor());
+                    }
+                } catch (Exception e) {
+                    ExceptionHandler.process(e);
+                }
+            }, null);
+            executor.execute(cleanTask);
+        } catch (Exception e) {
+            ExceptionHandler.process(e);
+        }
+
+    }
+
+    public boolean isCleanTaskRunning() {
+        return cleanTask != null && !cleanTask.isDone();
+    }
+
+    public void clearCache() {
+        delayCount = 0;
+    }
+
+}

--- a/main/plugins/org.talend.migrationTool/src/org/talend/migrationtool/MigrationToolService.java
+++ b/main/plugins/org.talend.migrationTool/src/org/talend/migrationtool/MigrationToolService.java
@@ -64,6 +64,7 @@ import org.talend.core.model.repository.RepositoryObject;
 import org.talend.core.model.routines.CodesJarInfo;
 import org.talend.core.model.routines.RoutinesUtil;
 import org.talend.core.model.utils.MigrationUtil;
+import org.talend.core.prefs.HistoryStoreHelper;
 import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.core.repository.utils.ProjectDataJsonProvider;
 import org.talend.core.repository.utils.RoutineUtils;
@@ -230,6 +231,7 @@ public class MigrationToolService implements IMigrationToolService {
         log.trace(taskDesc);
 
         MigrationReportHelper.getInstance().clearRecorders();
+        HistoryStoreHelper.getInstance().clearCache();
         IRepositoryService service = (IRepositoryService) GlobalServiceRegister.getDefault().getService(IRepositoryService.class);
         final IProxyRepositoryFactory repFactory = service.getProxyRepositoryFactory();
         final IWorkspace workspace = ResourcesPlugin.getWorkspace();

--- a/main/plugins/org.talend.repository.items.importexport/src/main/java/org/talend/repository/items/importexport/handlers/ImportExportHandlersManager.java
+++ b/main/plugins/org.talend.repository.items.importexport/src/main/java/org/talend/repository/items/importexport/handlers/ImportExportHandlersManager.java
@@ -65,6 +65,7 @@ import org.talend.core.model.repository.DynaEnum;
 import org.talend.core.model.repository.ERepositoryObjectType;
 import org.talend.core.model.repository.IRepositoryViewObject;
 import org.talend.core.model.routines.CodesJarInfo;
+import org.talend.core.prefs.HistoryStoreHelper;
 import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.core.runtime.CoreRuntimePlugin;
 import org.talend.core.ui.IJobletProviderService;
@@ -655,6 +656,8 @@ public class ImportExportHandlersManager {
                             }
 
                             try {
+                                // clean resource history save disk storage
+                                HistoryStoreHelper.getInstance().clearCache();
                                 forceDeleteWithRelationsBeforeOverwriteImport(monitor, resManager, allImportItemRecords,
                                         checkedItemRecords, overwriteDeletedItems, idDeletedBeforeImport);
 
@@ -798,6 +801,7 @@ public class ImportExportHandlersManager {
                                         if (monitor.isCanceled()) {
                                             return;
                                         }
+                                        HistoryStoreHelper.getInstance().checkAndClean();
                                         pendoImportManager.countItem(itemRecord);
                                         // will import
                                         importHandler.doImport(monitor, manager, itemRecord, overwriting, destinationPath);


### PR DESCRIPTION
reducing disk space usage
https://jira.talendforge.org/browse/TUP-41569